### PR TITLE
vLLM/SGLang integration, multi-vendor data plane, io_uring backend, and tuning

### DIFF
--- a/bodocache/adapters/uring_backend.py
+++ b/bodocache/adapters/uring_backend.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+
+class SegmentedUringBackend:
+    """Segmented backend using io_uring (native module) for high-throughput reads.
+
+    Falls back to raising ImportError if the native module is not available.
+    """
+
+    def __init__(self, root: str):
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        try:
+            import bodocache_agent_io_uring as uring  # type: ignore
+        except Exception as e:  # pragma: no cover - optional dependency
+            raise ImportError("bodocache_agent_io_uring module not found. Build with -DUSE_URING=ON")
+        self._uring = uring
+
+    def _seg_path(self, model_id: str, model_version: str, layer: int) -> Path:
+        p = self.root / model_id / model_version / f"layer_{layer}.seg"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        return p
+
+    def read_range_into(
+        self,
+        model_id: str,
+        model_version: str,
+        layer: int,
+        start_pid: int,
+        end_pid: int,
+        page_bytes: int,
+        out_buf,
+    ) -> int:
+        if end_pid < start_pid:
+            return 0
+        p = self._seg_path(model_id, model_version, layer)
+        size = (end_pid - start_pid + 1) * page_bytes
+        offset = start_pid * page_bytes
+        return int(self._uring.read_range_into(str(p), int(offset), int(size), out_buf))
+

--- a/bodocache/agent/capabilities.py
+++ b/bodocache/agent/capabilities.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class BackendCaps:
+    cuda: bool = False
+    hip: bool = False
+    l0: bool = False
+    io_uring: bool = False
+
+
+def detect_backends() -> BackendCaps:
+    caps = BackendCaps()
+    # CUDA/HIP/L0 are inferred by import of native module if built;
+    # expose booleans so apps can choose preferred backend.
+    try:
+        import bodocache_agent_copy_engine as ce  # type: ignore
+        # Heuristic: backend macro not visible; we inspect symbols by name
+        # or try to instantiate and catch errors per platform.
+        # Here we simply note presence of a native engine.
+        caps.cuda = True  # Mark generic native available; precise detection left to environment
+    except Exception:
+        pass
+    # HIP and L0 detection are platform-specific; leave false unless explicitly built
+    # io_uring module
+    try:
+        import bodocache_agent_io_uring  # type: ignore
+        caps.io_uring = True
+    except Exception:
+        pass
+    return caps
+

--- a/bodocache/agent/copy_engine.py
+++ b/bodocache/agent/copy_engine.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional, Protocol
+
+
+@dataclass
+class CopyOp:
+    """Generic copy operation descriptor.
+
+    This is intentionally vendor-neutral. Native backends may reinterpret
+    fields as device pointers/stream ids. The simulation backend uses
+    Python bytes for src.
+    """
+
+    # In a native engine, `src` would be a pointer into pinned host memory.
+    # In the sim backend we pass Python `bytes`.
+    src: Any
+    # Destination descriptor (engine/adapter-specific). For native engines,
+    # this would be a device pointer plus shape/stride metadata managed by the
+    # integration adapter.
+    dst: Any
+    bytes: int
+    stream_id: int = 0
+    gpu_id: int = 0
+    deadline_ms: int = 0
+
+
+class AbstractCopyEngine(Protocol):
+    def submit(self, ops: List[CopyOp], callback: Callable[[CopyOp], None]) -> None:
+        """Submit a batch of copy ops and invoke callback as they complete."""
+
+
+class SimCopyEngine:
+    """A minimal in-process, CPU-only engine.
+
+    This is a placeholder to preserve functionality without requiring a
+    compiled backend. It immediately invokes the callback for each op.
+    """
+
+    def submit(self, ops: List[CopyOp], callback: Callable[[CopyOp], None]) -> None:  # type: ignore[override]
+        # Micro-sleep to mimic async behavior without blocking too long.
+        for op in ops:
+            # 0.05ms per op for a tiny hint of asynchrony
+            time.sleep(0.00005)
+            callback(op)
+
+    def acquire_host_buffer(self, nbytes: int):  # type: ignore[override]
+        # Return a writable bytearray as a stand-in for pinned memory.
+        return memoryview(bytearray(nbytes))
+
+
+def load_native_copy_engine() -> Optional[AbstractCopyEngine]:
+    """Try loading a native (pybind11) copy engine if available.
+
+    The expected module name can be standardized later. For now, we probe a
+    couple of common names and fall back to None if not present.
+    """
+    candidates = (
+        "bodocache_agent_copy_engine",
+        "bodocache.copy_engine_native",
+        "copy_engine_native",
+    )
+    for name in candidates:
+        try:  # pragma: no cover - import optional native module
+            mod = __import__(name, fromlist=["CopyEngine"])  # type: ignore
+            engine = getattr(mod, "CopyEngine", None)
+            if engine is not None:
+                return engine()  # type: ignore[return-value]
+        except Exception:
+            continue
+    return None
+
+
+def get_copy_engine(prefer_native: bool = True) -> AbstractCopyEngine:
+    """Return a usable copy engine instance.
+
+    - If prefer_native is True and a native engine is importable, use it.
+    - Otherwise use the SimCopyEngine.
+    """
+    if prefer_native:
+        native = load_native_copy_engine()
+        if native is not None:
+            return native
+    return SimCopyEngine()

--- a/bodocache/agent/node_agent.py
+++ b/bodocache/agent/node_agent.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import time
-from typing import Callable, Dict, Any
+from typing import Callable, Dict, Any, Optional
 
 import numpy as np
 import pandas as pd
 
 from bodocache.adapters.segmented_file_backend import SegmentedFileBackend
+from .copy_engine import AbstractCopyEngine, CopyOp, get_copy_engine
 
 
 class NodeAgent:
@@ -15,26 +16,117 @@ class NodeAgent:
     This models STORAGE->CPU transfers as coalesced reads from segment files.
     """
 
-    def __init__(self, backend: SegmentedFileBackend, page_bytes: int = 256 * 1024):
+    def __init__(
+        self,
+        backend: SegmentedFileBackend,
+        page_bytes: int = 256 * 1024,
+        copy_engine: Optional[AbstractCopyEngine] = None,
+    ):
         self.backend = backend
         self.page_bytes = page_bytes
+        # Optional device copy engine. Falls back to a simulated engine if explicitly requested.
+        self.copy_engine = copy_engine
 
-    def execute(self, plan_df: pd.DataFrame, model_id: str, model_version: str, on_ready: Callable[[Dict[str, Any]], None] | None = None) -> Dict[str, Any]:
+    def execute(
+        self,
+        plan_df: pd.DataFrame,
+        model_id: str,
+        model_version: str,
+        on_ready: Optional[Callable[[Dict[str, Any]], None]] = None,
+        dest_resolver: Optional[Callable[[Dict[str, Any]], Any]] = None,
+        prefer_native_engine: bool = True,
+    ) -> Dict[str, Any]:
         if plan_df.empty:
             return {"ops": 0, "bytes": 0, "duration_ms": 0.0}
         t0 = time.time()
         total_bytes = 0
         for r in plan_df.itertuples(index=False):
-            data = self.backend.read_range(model_id, model_version, int(r.layer), int(r.start_pid), int(r.end_pid), int(getattr(r, 'page_bytes', self.page_bytes)))
-            total_bytes += len(data)
-            if on_ready is not None:
-                on_ready({
-                    "node": getattr(r, 'node', ''),
-                    "layer": int(r.layer),
-                    "start_pid": int(r.start_pid),
-                    "end_pid": int(r.end_pid),
-                    "bytes": len(data),
-                })
+            layer = int(r.layer)
+            start_pid = int(r.start_pid)
+            end_pid = int(r.end_pid)
+            page_bytes = int(getattr(r, "page_bytes", self.page_bytes))
+            # Compute total bytes for this coalesced read
+            nbytes = (end_pid - start_pid + 1) * page_bytes if end_pid >= start_pid else 0
+            total_bytes += nbytes
+
+            # If a device copy engine is available and a destination is provided, enqueue a copy.
+            # Otherwise, treat the read as "ready" immediately.
+            if self.copy_engine is None and dest_resolver is not None and prefer_native_engine:
+                # Try to lazily load a native engine if requested and not provided.
+                self.copy_engine = get_copy_engine(prefer_native=prefer_native_engine)
+
+            dst = dest_resolver({
+                "node": getattr(r, "node", ""),
+                "layer": layer,
+                "start_pid": start_pid,
+                "end_pid": end_pid,
+                "bytes": nbytes,
+            }) if dest_resolver is not None else None
+
+            if self.copy_engine is not None and dst is not None:
+                # Use pinned buffer path if supported by the engine
+                src_buf = None
+                acquire = getattr(self.copy_engine, "acquire_host_buffer", None)
+                if callable(acquire) and nbytes > 0:
+                    try:
+                        src_buf = acquire(nbytes)  # expected to be a writable memoryview
+                    except Exception:
+                        src_buf = None
+
+                if src_buf is not None:
+                    # Read directly into pinned buffer and submit device copy
+                    self.backend.read_range_into(
+                        model_id,
+                        model_version,
+                        layer,
+                        start_pid,
+                        end_pid,
+                        page_bytes,
+                        src_buf,
+                    )
+                    op = CopyOp(
+                        src=src_buf,
+                        dst=dst,
+                        bytes=nbytes,
+                        stream_id=int(getattr(r, "overlap", 1)) - 1 if hasattr(r, "overlap") else 0,
+                        gpu_id=int(getattr(r, "gpu_id", 0)) if hasattr(r, "gpu_id") else 0,
+                        deadline_ms=int(getattr(r, "deadline_ms", 0)) if hasattr(r, "deadline_ms") else 0,
+                    )
+
+                    def _done(_op: CopyOp, _r=r) -> None:
+                        if on_ready is not None:
+                            on_ready(
+                                {
+                                    "node": getattr(_r, "node", ""),
+                                    "layer": int(_r.layer),
+                                    "start_pid": int(_r.start_pid),
+                                    "end_pid": int(_r.end_pid),
+                                    "bytes": nbytes,
+                                }
+                            )
+
+                    # Submit as a single-op batch to keep context simple.
+                    self.copy_engine.submit([op], _done)
+                    continue
+
+            # Fallback: CPU read and mark ready
+            data = self.backend.read_range(
+                model_id,
+                model_version,
+                layer,
+                start_pid,
+                end_pid,
+                page_bytes,
+            )
+            if on_ready is not None and nbytes > 0:
+                on_ready(
+                    {
+                        "node": getattr(r, "node", ""),
+                        "layer": layer,
+                        "start_pid": start_pid,
+                        "end_pid": end_pid,
+                        "bytes": len(data),
+                    }
+                )
         dt = (time.time() - t0) * 1000.0
         return {"ops": int(len(plan_df)), "bytes": int(total_bytes), "duration_ms": float(dt)}
-

--- a/bodocache/integrations/__init__.py
+++ b/bodocache/integrations/__init__.py
@@ -1,0 +1,12 @@
+from .base import KVRequest, PlannerInputs, build_dataframes
+from .vllm_adapter import VLLMBCacheAdapter
+from .sglang_adapter import SGLangBCacheAdapter
+
+__all__ = [
+    "KVRequest",
+    "PlannerInputs",
+    "build_dataframes",
+    "VLLMBCacheAdapter",
+    "SGLangBCacheAdapter",
+]
+

--- a/bodocache/integrations/base.py
+++ b/bodocache/integrations/base.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class KVRequest:
+    """A single KV page interval request originating from an engine.
+
+    All fields map directly to columns expected by the planner scheduler.
+    """
+
+    req_id: str
+    node: str
+    model_id: str
+    model_version: str
+    prefix_id: str
+    layer: int
+    page_start: int
+    page_end: int
+    page_bytes: int = 256 * 1024
+    tenant: str = "default"
+    est_fill_ms: float = 1.0
+    tier_src: int = 0  # storage
+    tier_dst: int = 2  # gpu
+    deadline_ms: int = 0
+
+
+@dataclass
+class PlannerInputs:
+    """Planner side inputs for a single planning window."""
+
+    requests: List[KVRequest]
+    window_ms: int = 20
+    now_ms: int = 0
+    # Per-tier capacities: bytes per window and free bytes; indices by tier id
+    bandwidth_caps: Optional[dict[int, int]] = None
+    free_bytes: Optional[dict[int, int]] = None
+    # Per-tenant bandwidth caps (bytes per window) per tier
+    tenant_caps: Optional[List[tuple[str, int, int]]] = None  # (tenant, tier, cap)
+    # Per-layer latencies (ms)
+    layer_lat_ms: Optional[dict[int, float]] = None
+
+
+def _default_bandwidth_caps(window_ms: int) -> dict[int, int]:
+    # Approximate bytes-per-window caps (20ms) for tiers: STORAGE=0, CPU=1, GPU=2
+    # GPU: ~25 GB/s -> ~500 MB per 20ms window
+    # CPU: ~10 GB/s -> ~200 MB per 20ms window
+    # STORAGE: ~3 GB/s -> ~60 MB per 20ms window (coalesced reads)
+    return {0: 60 * 1024 * 1024, 1: 200 * 1024 * 1024, 2: 500 * 1024 * 1024}
+
+
+def build_dataframes(pi: PlannerInputs):
+    """Construct the DataFrames required by scheduler.run_window from inputs."""
+    if not pi.requests:
+        # Empty frames with correct columns
+        cols_req = [
+            "req_id",
+            "node",
+            "model_id",
+            "model_version",
+            "prefix_id",
+            "layer",
+            "page_start",
+            "page_end",
+            "tier_src",
+            "tier_dst",
+            "deadline_ms",
+            "page_bytes",
+            "tenant",
+            "est_fill_ms",
+        ]
+        empty = pd.DataFrame(columns=cols_req)
+        heat = pd.DataFrame(columns=["layer", "page_id", "decay_hits", "tenant_weight", "size_bytes"])
+        caps = pd.DataFrame(columns=["tier", "bandwidth_caps", "free_bytes"])
+        tcaps = pd.DataFrame(columns=["tenant", "tier", "bandwidth_caps"])
+        ll = pd.DataFrame(columns=["layer", "lat_ms"])
+        return empty, heat, caps, tcaps, ll
+
+    # requests_df
+    rows = [
+        (
+            r.req_id,
+            r.node,
+            r.model_id,
+            r.model_version,
+            r.prefix_id,
+            int(r.layer),
+            int(r.page_start),
+            int(r.page_end),
+            int(r.tier_src),
+            int(r.tier_dst),
+            int(r.deadline_ms),
+            int(r.page_bytes),
+            r.tenant,
+            float(r.est_fill_ms),
+        )
+        for r in pi.requests
+    ]
+    requests_df = pd.DataFrame(
+        rows,
+        columns=[
+            "req_id",
+            "node",
+            "model_id",
+            "model_version",
+            "prefix_id",
+            "layer",
+            "page_start",
+            "page_end",
+            "tier_src",
+            "tier_dst",
+            "deadline_ms",
+            "page_bytes",
+            "tenant",
+            "est_fill_ms",
+        ],
+    )
+
+    # heat_df: default decay_hits=1, tenant_weight=1.0, size_bytes=page_bytes
+    heat_df = requests_df[["layer", "page_start", "page_bytes"]].copy()
+    heat_df = heat_df.rename(columns={"page_start": "page_id", "page_bytes": "size_bytes"})
+    heat_df["decay_hits"] = np.int64(1)
+    heat_df["tenant_weight"] = np.float64(1.0)
+    heat_df = heat_df.groupby(["layer", "page_id"], as_index=False).agg(
+        decay_hits=("decay_hits", "sum"), tenant_weight=("tenant_weight", "first"), size_bytes=("size_bytes", "max")
+    )
+
+    # tier_caps_df
+    bw_caps = pi.bandwidth_caps or _default_bandwidth_caps(pi.window_ms)
+    free = pi.free_bytes or {0: 1 << 60, 1: 1 << 60, 2: 1 << 60}
+    caps_rows = [
+        (tier, int(bw_caps.get(tier, 0)), int(free.get(tier, 1 << 60))) for tier in sorted(set([0, 1, 2]).union(bw_caps.keys()).union(free.keys()))
+    ]
+    tier_caps_df = pd.DataFrame(caps_rows, columns=["tier", "bandwidth_caps", "free_bytes"])
+
+    # tenant_caps_df: if not provided, set very large caps
+    if pi.tenant_caps:
+        trows = [(t, int(tier), int(cap)) for (t, tier, cap) in pi.tenant_caps]
+    else:
+        tenants = requests_df["tenant"].unique().tolist()
+        trows = [(t, int(tier), int(1 << 60)) for t in tenants for tier in [0, 1, 2]]
+    tenant_caps_df = pd.DataFrame(trows, columns=["tenant", "tier", "bandwidth_caps"])
+
+    # layer_lat_df
+    if pi.layer_lat_ms:
+        lrows = [(int(k), float(v)) for k, v in sorted(pi.layer_lat_ms.items())]
+    else:
+        layers = requests_df["layer"].unique().tolist()
+        lrows = [(int(ly), 1.0) for ly in layers]
+    layer_lat_df = pd.DataFrame(lrows, columns=["layer", "lat_ms"])
+
+    return requests_df, heat_df, tier_caps_df, tenant_caps_df, layer_lat_df
+

--- a/bodocache/integrations/config.py
+++ b/bodocache/integrations/config.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Dict, Optional
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None  # type: ignore
+
+from .vllm_blocks import VLLMCacheConfig
+
+
+@dataclass
+class KVOverrides:
+    block_size: Optional[int] = None
+    num_layers: Optional[int] = None
+    num_kv_heads: Optional[int] = None
+    head_size: Optional[int] = None
+    kv_dtype: Optional[str] = None
+
+
+def apply_kv_overrides(cfg: VLLMCacheConfig, overrides: KVOverrides | Dict[str, Any] | None) -> VLLMCacheConfig:
+    if overrides is None:
+        return cfg
+    if isinstance(overrides, dict):
+        o = KVOverrides(**{k: overrides.get(k) for k in KVOverrides.__annotations__.keys()})
+    else:
+        o = overrides
+    return VLLMCacheConfig(
+        block_size=int(o.block_size if o.block_size is not None else cfg.block_size),
+        num_layers=int(o.num_layers if o.num_layers is not None else cfg.num_layers),
+        num_kv_heads=int(o.num_kv_heads if o.num_kv_heads is not None else cfg.num_kv_heads),
+        head_size=int(o.head_size if o.head_size is not None else cfg.head_size),
+        kv_dtype=str(o.kv_dtype if o.kv_dtype is not None else cfg.kv_dtype),
+    )
+
+
+def load_kv_overrides(path: str) -> KVOverrides:
+    if yaml is None:
+        raise ImportError("pyyaml is required to load overrides from YAML")
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    kv = data.get("kv", {})
+    return KVOverrides(
+        block_size=kv.get("block_size"),
+        num_layers=kv.get("num_layers"),
+        num_kv_heads=kv.get("num_kv_heads"),
+        head_size=kv.get("head_size"),
+        kv_dtype=kv.get("kv_dtype"),
+    )
+

--- a/bodocache/integrations/examples/sglang_example.py
+++ b/bodocache/integrations/examples/sglang_example.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+import time
+
+from bodocache.integrations.base import KVRequest
+from bodocache.integrations.sglang_adapter import SGLangBCacheAdapter
+from bodocache.integrations.sglang_glue import SGLangHook
+from bodocache.integrations.ptr import from_torch_tensor
+
+
+class SGLangRequestBuilder:
+    def __init__(self, page_bytes: int = 256 * 1024, tenant: str = "default") -> None:
+        self.page_bytes = page_bytes
+        self.tenant = tenant
+
+    def build_requests(self, sglang_state: Any) -> List[KVRequest]:
+        requests: List[KVRequest] = []
+        now_ms = int(time.time() * 1000)
+        for seq in getattr(sglang_state, "active_sequences", []):
+            prefix_id = getattr(seq, "prefix_id", str(seq))
+            for layer in range(getattr(sglang_state, "num_layers", 0)):
+                page_start, page_end = self._lookup_pages(seq, layer)
+                if page_start <= page_end:
+                    requests.append(
+                        KVRequest(
+                            req_id=f"{seq}:{layer}",
+                            node=getattr(sglang_state, "node", "n0"),
+                            model_id=getattr(sglang_state, "model_id", "m"),
+                            model_version=getattr(sglang_state, "model_version", "v"),
+                            prefix_id=prefix_id,
+                            layer=int(layer),
+                            page_start=int(page_start),
+                            page_end=int(page_end),
+                            page_bytes=self.page_bytes,
+                            tenant=self.tenant,
+                            est_fill_ms=1.0,
+                            tier_src=0,
+                            tier_dst=2,
+                            deadline_ms=now_ms + 20,
+                        )
+                    )
+        return requests
+
+    def _lookup_pages(self, seq: Any, layer: int) -> tuple[int, int]:
+        # TODO: implement using your KV page table
+        return (0, -1)
+
+
+def make_dest_resolver(kv_manager: Any):
+    def dest_resolver(info: Dict[str, Any]):
+        layer = info["layer"]
+        start_pid = info["start_pid"]
+        end_pid = info["end_pid"]
+        # tensor = kv_manager.get_tensor_slice(layer, start_pid, end_pid)
+        tensor = None
+        if tensor is None:
+            return None
+        return from_torch_tensor(tensor)
+
+    return dest_resolver
+
+
+def make_hook(adapter: SGLangBCacheAdapter, builder: SGLangRequestBuilder, kv_manager: Any) -> SGLangHook:
+    return SGLangHook(
+        adapter,
+        build_requests=builder.build_requests,
+        dest_resolver=make_dest_resolver(kv_manager),
+    )
+

--- a/bodocache/integrations/examples/vllm_example.py
+++ b/bodocache/integrations/examples/vllm_example.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+"""
+Example scaffolding for integrating BCache with vLLM.
+
+This file intentionally avoids importing vLLM to keep the package lightweight.
+Copy and customize in your serving stack.
+"""
+
+from typing import Any, Dict, List
+import time
+
+from bodocache.integrations.base import KVRequest
+from bodocache.integrations.vllm_adapter import VLLMBCacheAdapter
+from bodocache.integrations.vllm_glue import VLLMHook
+from bodocache.integrations.ptr import from_torch_tensor
+
+
+class VLLMRequestBuilder:
+    """Turn vLLM scheduler state into KVRequest objects.
+
+    You must map your KV cache page table into (layer, page_start, page_end)
+    intervals per active sequence.
+    """
+
+    def __init__(self, page_bytes: int = 256 * 1024, tenant: str = "default") -> None:
+        self.page_bytes = page_bytes
+        self.tenant = tenant
+
+    def build_requests(self, vllm_state: Any) -> List[KVRequest]:
+        # Pseudocode: walk active sequences and collect required KV page ranges
+        # Replace these with actual vLLM lookups.
+        requests: List[KVRequest] = []
+        now_ms = int(time.time() * 1000)
+        for seq in getattr(vllm_state, "active_sequences", []):
+            prefix_id = getattr(seq, "prefix_id", str(seq))
+            # Example: for next decode layer 0..L, use your page table to compute page ranges
+            for layer in range(getattr(vllm_state, "num_layers", 0)):
+                page_start, page_end = self._lookup_pages(seq, layer)
+                if page_start <= page_end:
+                    requests.append(
+                        KVRequest(
+                            req_id=f"{seq}:{layer}",
+                            node=getattr(vllm_state, "node", "n0"),
+                            model_id=getattr(vllm_state, "model_id", "m"),
+                            model_version=getattr(vllm_state, "model_version", "v"),
+                            prefix_id=prefix_id,
+                            layer=int(layer),
+                            page_start=int(page_start),
+                            page_end=int(page_end),
+                            page_bytes=self.page_bytes,
+                            tenant=self.tenant,
+                            est_fill_ms=1.0,
+                            tier_src=0,
+                            tier_dst=2,
+                            deadline_ms=now_ms + 20,  # e.g., next window
+                        )
+                    )
+        return requests
+
+    def _lookup_pages(self, seq: Any, layer: int) -> tuple[int, int]:
+        # TODO: implement using your KV page table
+        return (0, -1)
+
+
+def make_dest_resolver(kv_manager: Any):
+    """Create a dest_resolver capturing your KV manager to locate tensor slices.
+
+    The resolver receives a dict with {layer, start_pid, end_pid, bytes} and must
+    return a device pointer capsule for the destination memory region.
+    """
+
+    def dest_resolver(info: Dict[str, Any]):
+        layer = info["layer"]
+        start_pid = info["start_pid"]
+        end_pid = info["end_pid"]
+        # tensor = kv_manager.get_tensor_slice(layer, start_pid, end_pid)
+        tensor = None  # Replace with actual torch CUDA tensor
+        if tensor is None:
+            return None
+        return from_torch_tensor(tensor)
+
+    return dest_resolver
+
+
+def make_hook(adapter: VLLMBCacheAdapter, builder: VLLMRequestBuilder, kv_manager: Any) -> VLLMHook:
+    return VLLMHook(
+        adapter,
+        build_requests=builder.build_requests,
+        dest_resolver=make_dest_resolver(kv_manager),
+    )
+

--- a/bodocache/integrations/loader.py
+++ b/bodocache/integrations/loader.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any, Callable
+
+
+def load_callable(spec: str) -> Callable[..., Any]:
+    """Load a callable from a `module:function` spec string.
+
+    Example: `mypkg.mymodule:myfunc`
+    """
+    if ":" not in spec:
+        raise ValueError("spec must be 'module:function'")
+    mod_name, func_name = spec.split(":", 1)
+    mod = importlib.import_module(mod_name)
+    fn = getattr(mod, func_name)
+    if not callable(fn):
+        raise TypeError(f"{spec} is not callable")
+    return fn
+

--- a/bodocache/integrations/ptr.py
+++ b/bodocache/integrations/ptr.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any
+
+import types
+
+
+def device_ptr_capsule(ptr: int) -> Any:
+    """Create a PyCapsule that holds a raw device pointer.
+
+    Many frameworks (e.g., PyTorch) provide an integer pointer via `.data_ptr()`.
+    This helper wraps that integer as a capsule consumable by the native copy engine.
+    """
+    import ctypes
+    import sys
+
+    name = b"device_ptr"
+    # Create a capsule using CPython C-API via ctypes
+    # PyCapsule* PyCapsule_New(void *pointer, const char *name, PyCapsule_Destructor destructor)
+    PyCapsule_New = ctypes.pythonapi.PyCapsule_New
+    PyCapsule_New.restype = ctypes.py_object
+    PyCapsule_New.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_void_p]
+    return PyCapsule_New(ctypes.c_void_p(ptr), name, None)
+
+
+def from_torch_tensor(tensor: Any) -> Any:
+    """Return a device pointer capsule for a torch.Tensor (CUDA/HIP) without importing torch here.
+
+    The caller should have a torch tensor; we avoid hard dependency to keep the package light.
+    """
+    ptr = int(getattr(tensor, "data_ptr")())
+    return device_ptr_capsule(ptr)
+

--- a/bodocache/integrations/sglang_adapter.py
+++ b/bodocache/integrations/sglang_adapter.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Sequence
+import time
+
+import pandas as pd
+
+from bodocache.planner.scheduler import run_window
+from bodocache.agent.node_agent import NodeAgent
+from .base import KVRequest, PlannerInputs, build_dataframes
+from bodocache.telemetry.trace import TraceRecorder, PrefetchEvent
+
+
+ReadyCallback = Callable[[Dict[str, Any]], None]
+
+
+@dataclass
+class PrefetchResult:
+    plan_df: pd.DataFrame
+    evict_df: pd.DataFrame
+    admission_df: pd.DataFrame
+    exec_stats: Dict[str, Any]
+    metrics: Dict[str, Any] | None = None
+
+
+class SGLangBCacheAdapter:
+    """BCache adapter for SGLang.
+
+    Mirrors the vLLM adapter interface for symmetry.
+    """
+
+    def __init__(
+        self,
+        agent: NodeAgent,
+        *,
+        node: str,
+        model_id: str,
+        model_version: str,
+        pmin: float = 1.0,
+        umin: float = 0.0,
+        min_io_bytes: int = 512 * 1024,
+        alpha: float = 1.0,
+        beta: float = 0.0,
+        window_ms: int = 20,
+        max_ops_per_tier: int = 64,
+        enforce_tier_caps: bool = True,
+        on_evict: Optional[Callable[[pd.DataFrame], None]] = None,
+        on_admit: Optional[Callable[[pd.DataFrame], None]] = None,
+        capture_metrics: bool = True,
+        trace: Optional[TraceRecorder] = None,
+    ) -> None:
+        self.agent = agent
+        self.node = node
+        self.model_id = model_id
+        self.model_version = model_version
+        # Planner knobs
+        self.pmin = pmin
+        self.umin = umin
+        self.min_io = min_io_bytes
+        self.alpha = alpha
+        self.beta = beta
+        self.window_ms = window_ms
+        self.max_ops = max_ops_per_tier
+        self.enforce_caps = enforce_tier_caps
+        self.on_evict = on_evict
+        self.on_admit = on_admit
+        self.capture_metrics = capture_metrics
+        self.trace = trace
+
+    def prefetch(
+        self,
+        requests: Sequence[KVRequest],
+        *,
+        now_ms: int,
+        bandwidth_caps: Optional[dict[int, int]] = None,
+        free_bytes: Optional[dict[int, int]] = None,
+        layer_lat_ms: Optional[dict[int, float]] = None,
+        tenant_caps: Optional[List[tuple[str, int, int]]] = None,
+        on_ready: Optional[ReadyCallback] = None,
+        dest_resolver: Optional[Callable[[Dict[str, Any]], Any]] = None,
+    ) -> PrefetchResult:
+        # Prepare planner inputs
+        pi = PlannerInputs(
+            requests=list(requests),
+            window_ms=self.window_ms,
+            now_ms=now_ms,
+            bandwidth_caps=bandwidth_caps,
+            free_bytes=free_bytes,
+            tenant_caps=tenant_caps,
+            layer_lat_ms=layer_lat_ms,
+        )
+        req_df, heat_df, tier_caps_df, tenant_caps_df, layer_lat_df = build_dataframes(pi)
+
+        if not req_df.empty:
+            req_df["node"] = self.node
+            req_df["model_id"] = self.model_id
+            req_df["model_version"] = self.model_version
+
+        plan_df, evict_df, admission_df = run_window(
+            req_df,
+            heat_df,
+            tier_caps_df,
+            tenant_caps_df,
+            layer_lat_df,
+            now_ms=now_ms,
+            pmin=self.pmin,
+            umin=self.umin,
+            min_io_bytes=self.min_io,
+            alpha=self.alpha,
+            beta=self.beta,
+            window_ms=self.window_ms,
+            max_ops_per_tier=self.max_ops,
+            enable_admission=True,
+            enable_eviction=True,
+            enforce_tier_caps=self.enforce_caps,
+        )
+
+        # Optional eviction/admission
+        if self.on_evict is not None and not evict_df.empty:
+            try:
+                self.on_evict(evict_df)
+            except Exception:
+                pass
+        if self.on_admit is not None and not admission_df.empty:
+            try:
+                self.on_admit(admission_df)
+            except Exception:
+                pass
+
+        deadlines: Dict[tuple, float] = {}
+        if self.capture_metrics and not plan_df.empty:
+            base = float(now_ms)
+            for r in plan_df.itertuples(index=False):
+                key = (int(getattr(r, 'layer', -1)), int(getattr(r, 'start_pid', -1)), int(getattr(r, 'end_pid', -1)))
+                deadlines[key] = float(getattr(r, 'deadline_ms', base)) - base
+
+        ready_count = 0
+        on_time_count = 0
+
+        def _wrap_on_ready(info: Dict[str, Any]):
+            nonlocal ready_count, on_time_count
+            ready_count += 1
+            if self.capture_metrics and deadlines:
+                key = (int(info.get('layer', -1)), int(info.get('start_pid', -1)), int(info.get('end_pid', -1)))
+                finish = (time.time() * 1000.0) - float(now_ms)
+                deadline = deadlines.get(key, float('inf'))
+                if finish <= deadline:
+                    on_time_count += 1
+                if self.trace is not None:
+                    try:
+                        ev = PrefetchEvent(
+                            window_ms=self.window_ms,
+                            now_ms=int(now_ms),
+                            node=self.node,
+                            model_id=self.model_id,
+                            model_version=self.model_version,
+                            layer=int(info.get('layer', -1)),
+                            start_pid=int(info.get('start_pid', -1)),
+                            end_pid=int(info.get('end_pid', -1)),
+                            bytes=int(info.get('bytes', 0)),
+                            deadline_rel_ms=float(deadline),
+                            finish_rel_ms=float(finish),
+                            on_time=int(1 if finish <= deadline else 0),
+                        )
+                        self.trace.record(ev)
+                    except Exception:
+                        pass
+            if on_ready is not None:
+                on_ready(info)
+
+        stats = self.agent.execute(
+            plan_df,
+            model_id=self.model_id,
+            model_version=self.model_version,
+            on_ready=_wrap_on_ready if (self.capture_metrics or on_ready is not None) else None,
+            dest_resolver=dest_resolver,
+        )
+
+        metrics = None
+        if self.capture_metrics and ready_count > 0:
+            metrics = {
+                "ready_count": int(ready_count),
+                "on_time_ratio": float(on_time_count / max(1, ready_count)),
+            }
+
+        return PrefetchResult(plan_df=plan_df, evict_df=evict_df, admission_df=admission_df, exec_stats=stats, metrics=metrics)

--- a/bodocache/integrations/sglang_collectors.py
+++ b/bodocache/integrations/sglang_collectors.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .ptr import from_torch_tensor
+
+
+def make_sglang_collector(engine: Any):
+    bm = getattr(engine, "block_manager", None) or getattr(engine, "cache_engine", None)
+
+    def collector(state: Any) -> Dict[int, List[int]]:
+        if bm is not None:
+            for name in ("next_required_blocks", "get_required_blocks", "collect_required_blocks"):
+                fn = getattr(bm, name, None)
+                if callable(fn):
+                    out = fn(state)
+                    if out is not None:
+                        return {int(k): list(map(int, v)) for k, v in out.items()}
+        for name in ("next_required_blocks", "get_required_blocks", "collect_required_blocks"):
+            fn = getattr(engine, name, None)
+            if callable(fn):
+                out = fn(state)
+                if out is not None:
+                    return {int(k): list(map(int, v)) for k, v in out.items()}
+        m = getattr(state, "layer_to_blocks", None)
+        if isinstance(m, dict):
+            return {int(k): list(map(int, v)) for k, v in m.items()}
+        raise RuntimeError("could not collect required blocks from engine/state")
+
+    return collector
+
+
+def make_sglang_dest_resolver(kv_manager: Any):
+    def _as_ptr(obj: Any) -> Any:
+        if hasattr(obj, "data_ptr") and callable(getattr(obj, "data_ptr")):
+            return from_torch_tensor(obj)
+        try:
+            return int(obj)
+        except Exception:
+            return None
+
+    def resolver(info: Dict[str, Any]):
+        layer = int(info["layer"])
+        start = int(info["start_pid"])
+        end = int(info["end_pid"])
+        for name in (
+            "get_tensor_slice",
+            "get_block_tensor",
+            "get_range_tensor",
+            "get_dest_tensor",
+        ):
+            fn = getattr(kv_manager, name, None)
+            if callable(fn):
+                t = fn(layer, start, end)
+                ptr = _as_ptr(t)
+                if ptr is not None:
+                    return ptr
+        try:
+            t = kv_manager[(layer, start, end)]
+            ptr = _as_ptr(t)
+            if ptr is not None:
+                return ptr
+        except Exception:
+            pass
+        return None
+
+    return resolver
+

--- a/bodocache/integrations/sglang_glue.py
+++ b/bodocache/integrations/sglang_glue.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional, Sequence
+
+from .base import KVRequest
+from .sglang_adapter import SGLangBCacheAdapter
+
+
+BuildRequestsFn = Callable[[Any], Sequence[KVRequest]]
+DestResolverFn = Callable[[Dict[str, Any]], Any]
+ReadyCallback = Callable[[Dict[str, Any]], None]
+
+
+class SGLangHook:
+    """Drive BCache prefetch from SGLang by calling `prefetch()` per decode window.
+
+    This glue relies on callables that understand SGLang's scheduler/kv state and
+    produce KVRequest sequences and destination pointers.
+    """
+
+    def __init__(
+        self,
+        adapter: SGLangBCacheAdapter,
+        *,
+        build_requests: BuildRequestsFn,
+        dest_resolver: Optional[DestResolverFn] = None,
+        on_ready: Optional[ReadyCallback] = None,
+        bandwidth_caps: Optional[dict[int, int]] = None,
+        free_bytes: Optional[dict[int, int]] = None,
+        layer_lat_ms: Optional[dict[int, float]] = None,
+    ) -> None:
+        self.adapter = adapter
+        self.build_requests = build_requests
+        self.dest_resolver = dest_resolver
+        self.on_ready = on_ready
+        self.bandwidth_caps = bandwidth_caps
+        self.free_bytes = free_bytes
+        self.layer_lat_ms = layer_lat_ms
+
+    def prefetch_step(self, sglang_state: Any, now_ms: int) -> None:
+        reqs = self.build_requests(sglang_state)
+        self.adapter.prefetch(
+            reqs,
+            now_ms=now_ms,
+            bandwidth_caps=self.bandwidth_caps,
+            free_bytes=self.free_bytes,
+            layer_lat_ms=self.layer_lat_ms,
+            on_ready=self.on_ready,
+            dest_resolver=self.dest_resolver,
+        )
+

--- a/bodocache/integrations/sglang_integration.py
+++ b/bodocache/integrations/sglang_integration.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional, Sequence
+
+from .sglang_adapter import SGLangBCacheAdapter, PrefetchResult
+from .vllm_blocks import VLLMCacheConfig, build_requests_from_blocks
+from .config import KVOverrides, apply_kv_overrides
+
+
+CollectBlocksFn = Callable[[Any], Dict[int, Sequence[int]]]
+DestResolverFn = Callable[[Dict[str, Any]], Any]
+GetConfigFn = Callable[[Any], VLLMCacheConfig]
+
+
+def _safe_get(obj: Any, path: Sequence[str], default: Any = None) -> Any:
+    cur = obj
+    for name in path:
+        if cur is None:
+            return default
+        cur = getattr(cur, name, None)
+    return default if cur is None else cur
+
+
+def _maybe_int(x: Any, default: int = 0) -> int:
+    try:
+        return int(x)
+    except Exception:
+        return default
+
+
+def _maybe_str(x: Any, default: str = "") -> str:
+    try:
+        return str(x)
+    except Exception:
+        return default
+
+
+def _derive_config(engine: Any) -> VLLMCacheConfig:
+    # SGLang-like detection with similar fields
+    block_size = _maybe_int(_safe_get(engine, ("cache_config", "block_size"), 16), 16)
+    kv_dtype = _maybe_str(
+        _safe_get(engine, ("cache_config", "cache_dtype"), None)
+        or _safe_get(engine, ("cache_config", "kv_dtype"), "float16"),
+        "float16",
+    )
+    mc = getattr(engine, "model_config", None) or _safe_get(engine, ("engine", "model_config"), None)
+    num_layers = _maybe_int(getattr(mc, "num_hidden_layers", None), 0)
+    num_kv_heads = 0
+    if mc is not None:
+        if hasattr(mc, "get_num_kv_heads"):
+            try:
+                num_kv_heads = int(mc.get_num_kv_heads())
+            except Exception:
+                pass
+        if num_kv_heads <= 0:
+            num_kv_heads = _maybe_int(getattr(mc, "num_key_value_heads", None), 0)
+        if num_kv_heads <= 0:
+            num_kv_heads = _maybe_int(getattr(mc, "num_attention_heads", None), 0)
+    head_size = _maybe_int(getattr(mc, "head_size", None), 0)
+    if head_size <= 0:
+        hidden = _maybe_int(getattr(mc, "hidden_size", None), 0)
+        attn_heads = _maybe_int(getattr(mc, "num_attention_heads", None), 1) or 1
+        if hidden > 0 and attn_heads > 0:
+            head_size = int(hidden // attn_heads)
+    if num_layers <= 0:
+        num_layers = 1
+    if num_kv_heads <= 0:
+        num_kv_heads = 8
+    if head_size <= 0:
+        head_size = 64
+    return VLLMCacheConfig(
+        block_size=block_size,
+        num_layers=num_layers,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        kv_dtype=kv_dtype,
+    )
+
+
+class SGLangIntegration:
+    def __init__(
+        self,
+        engine: Any,
+        adapter: SGLangBCacheAdapter,
+        *,
+        tenant: str = "default",
+        get_config: Optional[GetConfigFn] = None,
+        collect_blocks: Optional[CollectBlocksFn] = None,
+        dest_resolver: Optional[DestResolverFn] = None,
+        kv_overrides: Optional[KVOverrides | Dict[str, Any]] = None,
+        deadline_offset_ms: Optional[int] = None,
+    ) -> None:
+        self.engine = engine
+        self.adapter = adapter
+        self.tenant = tenant
+        self._get_config = get_config
+        self._collect_blocks = collect_blocks
+        self._dest_resolver = dest_resolver
+        self._kv_overrides = kv_overrides
+        self._deadline_offset_ms = deadline_offset_ms
+
+    def _config(self) -> VLLMCacheConfig:
+        cfg = self._get_config(self.engine) if self._get_config is not None else _derive_config(self.engine)
+        return apply_kv_overrides(cfg, self._kv_overrides)
+
+    def prefetch_step(
+        self,
+        state: Any,
+        *,
+        prefix_id: str,
+        now_ms: int,
+        layer_lat_ms: Optional[Dict[int, float]] = None,
+        bandwidth_caps: Optional[Dict[int, int]] = None,
+        free_bytes: Optional[Dict[int, int]] = None,
+    ) -> Optional[PrefetchResult]:
+        cfg = self._config()
+        if self._collect_blocks is None:
+            return None
+        layer_to_blocks = self._collect_blocks(state)
+        kv_reqs = build_requests_from_blocks(
+            cfg,
+            node=getattr(self.engine, "node", "n0"),
+            model_id=_maybe_str(getattr(self.engine, "model_id", "m"), "m"),
+            model_version=_maybe_str(getattr(self.engine, "model_version", "v"), "v"),
+            tenant=self.tenant,
+            prefix_id=prefix_id,
+            layer_to_blocks=layer_to_blocks,
+            now_ms=now_ms,
+            deadline_offset_ms=int(self._deadline_offset_ms if self._deadline_offset_ms is not None else self.adapter.window_ms),
+        )
+        return self.adapter.prefetch(
+            kv_reqs,
+            now_ms=now_ms,
+            bandwidth_caps=bandwidth_caps,
+            free_bytes=free_bytes,
+            layer_lat_ms=layer_lat_ms,
+            dest_resolver=self._dest_resolver,
+        )

--- a/bodocache/integrations/vllm_adapter.py
+++ b/bodocache/integrations/vllm_adapter.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional, Sequence
+import time
+
+import pandas as pd
+
+from bodocache.planner.scheduler import run_window
+from bodocache.agent.node_agent import NodeAgent
+from .base import KVRequest, PlannerInputs, build_dataframes
+from bodocache.telemetry.trace import TraceRecorder, PrefetchEvent
+
+
+ReadyCallback = Callable[[Dict[str, Any]], None]
+
+
+@dataclass
+class PrefetchResult:
+    plan_df: pd.DataFrame
+    evict_df: pd.DataFrame
+    admission_df: pd.DataFrame
+    exec_stats: Dict[str, Any]
+    metrics: Dict[str, Any] | None = None
+
+
+class VLLMBCacheAdapter:
+    """Thin adapter to drive BCache planning/execution from vLLM.
+
+    Usage pattern inside vLLM (conceptually):
+      - Each decode step prepares KV page interval demands across active sequences.
+      - Call `prefetch()` with those demands and timing info.
+      - Optionally provide a `dest_resolver` that maps a (layer,page range) to a
+        destination GPU buffer/pointer in vLLM's KV cache.
+      - Receive metrics; the adapter issues on_ready callbacks per completed copy.
+    """
+
+    def __init__(
+        self,
+        agent: NodeAgent,
+        *,
+        node: str,
+        model_id: str,
+        model_version: str,
+        pmin: float = 1.0,
+        umin: float = 0.0,
+        min_io_bytes: int = 512 * 1024,
+        alpha: float = 1.0,
+        beta: float = 0.0,
+        window_ms: int = 20,
+        max_ops_per_tier: int = 64,
+        enforce_tier_caps: bool = True,
+        on_evict: Optional[Callable[[pd.DataFrame], None]] = None,
+        on_admit: Optional[Callable[[pd.DataFrame], None]] = None,
+        capture_metrics: bool = True,
+        trace: Optional[TraceRecorder] = None,
+    ) -> None:
+        self.agent = agent
+        self.node = node
+        self.model_id = model_id
+        self.model_version = model_version
+        # Planner knobs
+        self.pmin = pmin
+        self.umin = umin
+        self.min_io = min_io_bytes
+        self.alpha = alpha
+        self.beta = beta
+        self.window_ms = window_ms
+        self.max_ops = max_ops_per_tier
+        self.enforce_caps = enforce_tier_caps
+        self.on_evict = on_evict
+        self.on_admit = on_admit
+        self.capture_metrics = capture_metrics
+        self.trace = trace
+
+    def prefetch(
+        self,
+        requests: Sequence[KVRequest],
+        *,
+        now_ms: int,
+        bandwidth_caps: Optional[dict[int, int]] = None,
+        free_bytes: Optional[dict[int, int]] = None,
+        layer_lat_ms: Optional[dict[int, float]] = None,
+        tenant_caps: Optional[List[tuple[str, int, int]]] = None,
+        on_ready: Optional[ReadyCallback] = None,
+        dest_resolver: Optional[Callable[[Dict[str, Any]], Any]] = None,
+    ) -> PrefetchResult:
+        # Prepare planner inputs
+        pi = PlannerInputs(
+            requests=list(requests),
+            window_ms=self.window_ms,
+            now_ms=now_ms,
+            bandwidth_caps=bandwidth_caps,
+            free_bytes=free_bytes,
+            tenant_caps=tenant_caps,
+            layer_lat_ms=layer_lat_ms,
+        )
+        req_df, heat_df, tier_caps_df, tenant_caps_df, layer_lat_df = build_dataframes(pi)
+
+        # Inject node/model identifiers for all rows
+        if not req_df.empty:
+            req_df["node"] = self.node
+            req_df["model_id"] = self.model_id
+            req_df["model_version"] = self.model_version
+
+        # Plan
+        plan_df, evict_df, admission_df = run_window(
+            req_df,
+            heat_df,
+            tier_caps_df,
+            tenant_caps_df,
+            layer_lat_df,
+            now_ms=now_ms,
+            pmin=self.pmin,
+            umin=self.umin,
+            min_io_bytes=self.min_io,
+            alpha=self.alpha,
+            beta=self.beta,
+            window_ms=self.window_ms,
+            max_ops_per_tier=self.max_ops,
+            enable_admission=True,
+            enable_eviction=True,
+            enforce_tier_caps=self.enforce_caps,
+        )
+
+        # Optional eviction/admission side-effects
+        if self.on_evict is not None and not evict_df.empty:
+            try:
+                self.on_evict(evict_df)
+            except Exception:
+                pass
+        if self.on_admit is not None and not admission_df.empty:
+            try:
+                self.on_admit(admission_df)
+            except Exception:
+                pass
+
+        # Execute via NodeAgent (simulated or native engine)
+        deadlines: Dict[tuple, float] = {}
+        if self.capture_metrics and not plan_df.empty:
+            base = float(now_ms)
+            for r in plan_df.itertuples(index=False):
+                key = (int(getattr(r, 'layer', -1)), int(getattr(r, 'start_pid', -1)), int(getattr(r, 'end_pid', -1)))
+                deadlines[key] = float(getattr(r, 'deadline_ms', base)) - base
+
+        ready_count = 0
+        on_time_count = 0
+
+        def _wrap_on_ready(info: Dict[str, Any]):
+            nonlocal ready_count, on_time_count
+            ready_count += 1
+            if self.capture_metrics and deadlines:
+                key = (int(info.get('layer', -1)), int(info.get('start_pid', -1)), int(info.get('end_pid', -1)))
+                finish = (time.time() * 1000.0) - float(now_ms)
+                deadline = deadlines.get(key, float('inf'))
+                if finish <= deadline:
+                    on_time_count += 1
+                if self.trace is not None:
+                    try:
+                        ev = PrefetchEvent(
+                            window_ms=self.window_ms,
+                            now_ms=int(now_ms),
+                            node=self.node,
+                            model_id=self.model_id,
+                            model_version=self.model_version,
+                            layer=int(info.get('layer', -1)),
+                            start_pid=int(info.get('start_pid', -1)),
+                            end_pid=int(info.get('end_pid', -1)),
+                            bytes=int(info.get('bytes', 0)),
+                            deadline_rel_ms=float(deadline),
+                            finish_rel_ms=float(finish),
+                            on_time=int(1 if finish <= deadline else 0),
+                        )
+                        self.trace.record(ev)
+                    except Exception:
+                        pass
+            if on_ready is not None:
+                on_ready(info)
+
+        stats = self.agent.execute(
+            plan_df,
+            model_id=self.model_id,
+            model_version=self.model_version,
+            on_ready=_wrap_on_ready if (self.capture_metrics or on_ready is not None) else None,
+            dest_resolver=dest_resolver,
+        )
+
+        metrics = None
+        if self.capture_metrics and ready_count > 0:
+            metrics = {
+                "ready_count": int(ready_count),
+                "on_time_ratio": float(on_time_count / max(1, ready_count)),
+            }
+
+        return PrefetchResult(plan_df=plan_df, evict_df=evict_df, admission_df=admission_df, exec_stats=stats, metrics=metrics)

--- a/bodocache/integrations/vllm_blocks.py
+++ b/bodocache/integrations/vllm_blocks.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+from .base import KVRequest
+
+
+_DTYPE_BYTES = {
+    "float16": 2,
+    "bfloat16": 2,
+    "float32": 4,
+    "float8_e5m2": 1,
+    "float8_e4m3fn": 1,
+}
+
+
+@dataclass
+class VLLMCacheConfig:
+    block_size: int
+    num_layers: int
+    num_kv_heads: int
+    head_size: int
+    kv_dtype: str = "float16"
+
+    def bytes_per_block(self) -> int:
+        # 2 for K and V tensors
+        bpe = _DTYPE_BYTES.get(self.kv_dtype, 2)
+        return 2 * self.num_kv_heads * self.block_size * self.head_size * bpe
+
+
+def coalesce_blocks(block_ids: Sequence[int]) -> List[Tuple[int, int]]:
+    if not block_ids:
+        return []
+    s = sorted(set(int(b) for b in block_ids))
+    ranges = []
+    a = s[0]
+    prev = a
+    for b in s[1:]:
+        if b == prev + 1:
+            prev = b
+            continue
+        ranges.append((a, prev))
+        a = prev = b
+    ranges.append((a, prev))
+    return ranges
+
+
+def build_requests_from_blocks(
+    cfg: VLLMCacheConfig,
+    *,
+    node: str,
+    model_id: str,
+    model_version: str,
+    tenant: str,
+    prefix_id: str,
+    layer_to_blocks: Dict[int, Sequence[int]],
+    now_ms: int,
+    deadline_offset_ms: int = 20,
+) -> List[KVRequest]:
+    page_bytes = cfg.bytes_per_block()
+    reqs: List[KVRequest] = []
+    for layer, blocks in layer_to_blocks.items():
+        for start, end in coalesce_blocks(blocks):
+            reqs.append(
+                KVRequest(
+                    req_id=f"{prefix_id}:{layer}:{start}-{end}",
+                    node=node,
+                    model_id=model_id,
+                    model_version=model_version,
+                    prefix_id=prefix_id,
+                    layer=int(layer),
+                    page_start=int(start),
+                    page_end=int(end),
+                    page_bytes=int(page_bytes),
+                    tenant=tenant,
+                    est_fill_ms=1.0,
+                    tier_src=0,
+                    tier_dst=2,
+                    deadline_ms=int(now_ms + deadline_offset_ms),
+                )
+            )
+    return reqs
+

--- a/bodocache/integrations/vllm_collectors.py
+++ b/bodocache/integrations/vllm_collectors.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence
+
+from .ptr import from_torch_tensor
+
+
+def make_vllm_collector(engine: Any):
+    """Return a collector(state) -> Dict[layer, List[int]] for vLLM-like engines.
+
+    Tries several common APIs; override if your engine differs.
+    """
+
+    bm = getattr(engine, "block_manager", None) or getattr(engine, "cache_engine", None)
+
+    def collector(state: Any) -> Dict[int, List[int]]:
+        # Preferred engine APIs
+        if bm is not None:
+            for name in ("next_required_blocks", "get_required_blocks", "collect_required_blocks"):
+                fn = getattr(bm, name, None)
+                if callable(fn):
+                    out = fn(state)
+                    if out is not None:
+                        return {int(k): list(map(int, v)) for k, v in out.items()}
+        for name in ("next_required_blocks", "get_required_blocks", "collect_required_blocks"):
+            fn = getattr(engine, name, None)
+            if callable(fn):
+                out = fn(state)
+                if out is not None:
+                    return {int(k): list(map(int, v)) for k, v in out.items()}
+        # Fallback: accept a mapping on state directly
+        m = getattr(state, "layer_to_blocks", None)
+        if isinstance(m, dict):
+            return {int(k): list(map(int, v)) for k, v in m.items()}
+        raise RuntimeError("could not collect required blocks from engine/state")
+
+    return collector
+
+
+def make_vllm_dest_resolver(kv_manager: Any):
+    """Return dest_resolver(info) -> device pointer for vLLM KV destinations.
+
+    Tries common KV accessors and wraps torch tensors via from_torch_tensor.
+    """
+
+    def _as_ptr(obj: Any) -> Any:
+        # torch tensor
+        if hasattr(obj, "data_ptr") and callable(getattr(obj, "data_ptr")):
+            return from_torch_tensor(obj)
+        # raw int pointer
+        try:
+            return int(obj)
+        except Exception:
+            return None
+
+    def resolver(info: Dict[str, Any]):
+        layer = int(info["layer"])
+        start = int(info["start_pid"])
+        end = int(info["end_pid"])
+        # Try a set of common method names
+        for name in (
+            "get_tensor_slice",
+            "get_block_tensor",
+            "get_range_tensor",
+            "get_dest_tensor",
+        ):
+            fn = getattr(kv_manager, name, None)
+            if callable(fn):
+                t = fn(layer, start, end)
+                ptr = _as_ptr(t)
+                if ptr is not None:
+                    return ptr
+        # Try mapping access
+        try:
+            t = kv_manager[(layer, start, end)]
+            ptr = _as_ptr(t)
+            if ptr is not None:
+                return ptr
+        except Exception:
+            pass
+        return None
+
+    return resolver
+

--- a/bodocache/integrations/vllm_glue.py
+++ b/bodocache/integrations/vllm_glue.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
+
+from .base import KVRequest
+from .vllm_adapter import VLLMBCacheAdapter
+
+
+BuildRequestsFn = Callable[[Any], Sequence[KVRequest]]
+DestResolverFn = Callable[[Dict[str, Any]], Any]
+ReadyCallback = Callable[[Dict[str, Any]], None]
+
+
+class VLLMHook:
+    """Drive BCache prefetch from vLLM by calling `prefetch()` per decode window.
+
+    This glue does not import vLLM. You pass callables that know how to
+    translate vLLM's internal state into KVRequest sequences and how to map
+    a (layer, page-range) into a device destination pointer.
+    """
+
+    def __init__(
+        self,
+        adapter: VLLMBCacheAdapter,
+        *,
+        build_requests: BuildRequestsFn,
+        dest_resolver: Optional[DestResolverFn] = None,
+        on_ready: Optional[ReadyCallback] = None,
+        bandwidth_caps: Optional[dict[int, int]] = None,
+        free_bytes: Optional[dict[int, int]] = None,
+        layer_lat_ms: Optional[dict[int, float]] = None,
+    ) -> None:
+        self.adapter = adapter
+        self.build_requests = build_requests
+        self.dest_resolver = dest_resolver
+        self.on_ready = on_ready
+        self.bandwidth_caps = bandwidth_caps
+        self.free_bytes = free_bytes
+        self.layer_lat_ms = layer_lat_ms
+
+    def prefetch_step(self, vllm_state: Any, now_ms: int) -> None:
+        reqs = self.build_requests(vllm_state)
+        self.adapter.prefetch(
+            reqs,
+            now_ms=now_ms,
+            bandwidth_caps=self.bandwidth_caps,
+            free_bytes=self.free_bytes,
+            layer_lat_ms=self.layer_lat_ms,
+            on_ready=self.on_ready,
+            dest_resolver=self.dest_resolver,
+        )
+

--- a/bodocache/integrations/vllm_integration.py
+++ b/bodocache/integrations/vllm_integration.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional, Sequence
+
+from .vllm_adapter import VLLMBCacheAdapter, PrefetchResult
+from .vllm_blocks import VLLMCacheConfig, build_requests_from_blocks
+from .config import KVOverrides, apply_kv_overrides
+
+
+CollectBlocksFn = Callable[[Any], Dict[int, Sequence[int]]]
+DestResolverFn = Callable[[Dict[str, Any]], Any]
+GetConfigFn = Callable[[Any], VLLMCacheConfig]
+
+
+def _safe_get(obj: Any, path: Sequence[str], default: Any = None) -> Any:
+    cur = obj
+    for name in path:
+        if cur is None:
+            return default
+        cur = getattr(cur, name, None)
+    return default if cur is None else cur
+
+
+def _maybe_int(x: Any, default: int = 0) -> int:
+    try:
+        return int(x)
+    except Exception:
+        return default
+
+
+def _maybe_str(x: Any, default: str = "") -> str:
+    try:
+        return str(x)
+    except Exception:
+        return default
+
+
+def _derive_config(engine: Any) -> VLLMCacheConfig:
+    # Attempt to introspect vLLM-like engine configs; fall back to sensible defaults.
+    block_size = _maybe_int(_safe_get(engine, ("cache_config", "block_size"), 16), 16)
+    kv_dtype = _maybe_str(
+        _safe_get(engine, ("cache_config", "cache_dtype"), None)
+        or _safe_get(engine, ("cache_config", "kv_dtype"), "float16"),
+        "float16",
+    )
+
+    # Try typical vLLM locations for model config
+    mc = getattr(engine, "model_config", None) or _safe_get(engine, ("llm_engine", "model_config"), None)
+    num_layers = _maybe_int(getattr(mc, "num_hidden_layers", None), 0)
+
+    # num_kv_heads may be exposed via a method or attribute, else fall back
+    num_kv_heads = 0
+    if mc is not None:
+        if hasattr(mc, "get_num_kv_heads"):
+            try:
+                num_kv_heads = int(mc.get_num_kv_heads())
+            except Exception:
+                pass
+        if num_kv_heads <= 0:
+            num_kv_heads = _maybe_int(getattr(mc, "num_key_value_heads", None), 0)
+        if num_kv_heads <= 0:
+            num_kv_heads = _maybe_int(getattr(mc, "num_attention_heads", None), 0)
+
+    # head_size can be direct or derived from hidden_size/num_attention_heads
+    head_size = _maybe_int(getattr(mc, "head_size", None), 0)
+    if head_size <= 0:
+        hidden = _maybe_int(getattr(mc, "hidden_size", None), 0)
+        attn_heads = _maybe_int(getattr(mc, "num_attention_heads", None), 1) or 1
+        if hidden > 0 and attn_heads > 0:
+            head_size = int(hidden // attn_heads)
+
+    # Fallbacks to avoid zeros
+    if num_layers <= 0:
+        num_layers = 1
+    if num_kv_heads <= 0:
+        num_kv_heads = 8
+    if head_size <= 0:
+        head_size = 64
+
+    return VLLMCacheConfig(
+        block_size=block_size,
+        num_layers=num_layers,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        kv_dtype=kv_dtype,
+    )
+
+
+class VLLMIntegration:
+    """High-level integration that introspects vLLM engine configs and drives BCache prefetch.
+
+    Flexible by design: you can override config detection, block collection, and destination resolution via callables.
+    """
+
+    def __init__(
+        self,
+        engine: Any,
+        adapter: VLLMBCacheAdapter,
+        *,
+        tenant: str = "default",
+        get_config: Optional[GetConfigFn] = None,
+        collect_blocks: Optional[CollectBlocksFn] = None,
+        dest_resolver: Optional[DestResolverFn] = None,
+        kv_overrides: Optional[KVOverrides | Dict[str, Any]] = None,
+        deadline_offset_ms: Optional[int] = None,
+    ) -> None:
+        self.engine = engine
+        self.adapter = adapter
+        self.tenant = tenant
+        self._get_config = get_config
+        self._collect_blocks = collect_blocks
+        self._dest_resolver = dest_resolver
+        self._kv_overrides = kv_overrides
+        self._deadline_offset_ms = deadline_offset_ms
+
+    def _config(self) -> VLLMCacheConfig:
+        cfg = self._get_config(self.engine) if self._get_config is not None else _derive_config(self.engine)
+        return apply_kv_overrides(cfg, self._kv_overrides)
+
+    def prefetch_step(
+        self,
+        state: Any,
+        *,
+        prefix_id: str,
+        now_ms: int,
+        layer_lat_ms: Optional[Dict[int, float]] = None,
+        bandwidth_caps: Optional[Dict[int, int]] = None,
+        free_bytes: Optional[Dict[int, int]] = None,
+    ) -> Optional[PrefetchResult]:
+        cfg = self._config()
+        # Blocks per layer must be supplied; if not provided, bail early.
+        if self._collect_blocks is None:
+            return None
+        layer_to_blocks = self._collect_blocks(state)
+        kv_reqs = build_requests_from_blocks(
+            cfg,
+            node=getattr(self.engine, "node", "n0"),
+            model_id=_maybe_str(getattr(self.engine, "model_id", "m"), "m"),
+            model_version=_maybe_str(getattr(self.engine, "model_version", "v"), "v"),
+            tenant=self.tenant,
+            prefix_id=prefix_id,
+            layer_to_blocks=layer_to_blocks,
+            now_ms=now_ms,
+            deadline_offset_ms=int(self._deadline_offset_ms if self._deadline_offset_ms is not None else self.adapter.window_ms),
+        )
+        return self.adapter.prefetch(
+            kv_reqs,
+            now_ms=now_ms,
+            bandwidth_caps=bandwidth_caps,
+            free_bytes=free_bytes,
+            layer_lat_ms=layer_lat_ms,
+            dest_resolver=self._dest_resolver,
+        )

--- a/bodocache/planner/service_http.py
+++ b/bodocache/planner/service_http.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Dict, Tuple
+
+import pandas as pd
+
+from bodocache.planner.scheduler import run_window
+
+
+def df_from_json(obj: Any, columns: list[str]) -> pd.DataFrame:
+    if obj is None:
+        return pd.DataFrame(columns=columns)
+    return pd.DataFrame(obj, columns=columns)
+
+
+def plan_from_payload(payload: Dict[str, Any]) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    req = df_from_json(payload.get("requests"), [
+        "req_id","node","model_id","model_version","prefix_id","layer","page_start","page_end","tier_src","tier_dst","deadline_ms","page_bytes","tenant","est_fill_ms"
+    ])
+    heat = df_from_json(payload.get("heat"), ["layer","page_id","decay_hits","tenant_weight"])
+    tiers = df_from_json(payload.get("tier_caps"), ["tier","bandwidth_caps","free_bytes"])
+    tenant_caps = df_from_json(payload.get("tenant_caps"), ["tenant","tier","bandwidth_caps"])
+    lats = df_from_json(payload.get("layer_lat"), ["layer","lat_ms"])
+    now_ms = int(payload.get("now_ms", 0))
+    knobs = payload.get("knobs", {})
+
+    plan_df, evict_df, admission_df = run_window(
+        req, heat, tiers, tenant_caps, lats, now_ms,
+        pmin=float(knobs.get("pmin", 1.0)),
+        umin=float(knobs.get("umin", 0.0)),
+        min_io_bytes=int(knobs.get("min_io_bytes", 512*1024)),
+        alpha=float(knobs.get("alpha", 1.0)),
+        beta=float(knobs.get("beta", 0.0)),
+        window_ms=int(knobs.get("window_ms", 20)),
+        max_ops_per_tier=int(knobs.get("max_ops_per_tier", 64)),
+        enable_admission=bool(knobs.get("enable_admission", True)),
+        enable_eviction=bool(knobs.get("enable_eviction", True)),
+        enforce_tier_caps=bool(knobs.get("enforce_tier_caps", True)),
+    )
+    return plan_df, evict_df, admission_df
+
+
+class PlannerHandler(BaseHTTPRequestHandler):
+    def _send(self, code: int, body: Dict[str, Any]):
+        data = json.dumps(body).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        raw = self.rfile.read(length)
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except Exception as e:
+            self._send(400, {"error": f"invalid json: {e}"})
+            return
+        if self.path == "/get_plan":
+            try:
+                plan_df, evict_df, admission_df = plan_from_payload(payload)
+                body = {
+                    "plan": plan_df.to_dict(orient="records"),
+                    "evict": evict_df.to_dict(orient="records"),
+                    "admission": admission_df.to_dict(orient="records"),
+                }
+                self._send(200, body)
+            except Exception as e:
+                self._send(500, {"error": str(e)})
+        elif self.path == "/report":
+            # Accept perf counters and acknowledge
+            self._send(200, {"ok": True})
+        else:
+            self._send(404, {"error": "not found"})
+
+
+def serve(host: str = "0.0.0.0", port: int = 8080):
+    httpd = HTTPServer((host, port), PlannerHandler)
+    httpd.serve_forever()
+

--- a/configs/integration_overrides.example.yaml
+++ b/configs/integration_overrides.example.yaml
@@ -1,0 +1,23 @@
+# Example runtime overrides for engine integrations
+
+vllm:
+  kv:
+    # block_size: 16
+    # num_layers: 32
+    # num_kv_heads: 40
+    # head_size: 128
+    # kv_dtype: float16
+  # deadline_offset_ms: 20
+  # collect_blocks: mypkg.vllm_collectors:collect_blocks_v1
+  # dest_resolver: mypkg.vllm_collectors:resolve_dest_v1
+
+sglang:
+  kv:
+    # block_size: 16
+    # num_layers: 32
+    # num_kv_heads: 40
+    # head_size: 128
+    # kv_dtype: float16
+  # deadline_offset_ms: 20
+  # collect_blocks: mypkg.sgl_collectors:collect_blocks
+  # dest_resolver: mypkg.sgl_collectors:resolve_dest

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.20)
+project(bodocache_copy_engine LANGUAGES CXX)
+
+option(USE_CUDA "Build with CUDA backend" OFF)
+option(USE_HIP  "Build with HIP backend"  OFF)
+option(USE_L0   "Build with Level Zero backend" OFF)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development.Module)
+find_package(pybind11 REQUIRED)
+
+if (USE_CUDA)
+  enable_language(CUDA)
+  find_package(CUDAToolkit REQUIRED)
+  add_library(bodocache_copy_engine MODULE copy_engine_native_cuda.cu)
+  target_compile_definitions(bodocache_copy_engine PRIVATE USE_CUDA_BACKEND=1)
+  target_include_directories(bodocache_copy_engine PRIVATE ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
+  set_target_properties(bodocache_copy_engine PROPERTIES CUDA_ARCHITECTURES native)
+elseif(USE_HIP)
+  find_package(HIP REQUIRED)
+  hip_add_library(bodocache_copy_engine MODULE copy_engine_native_hip.cpp)
+  target_compile_definitions(bodocache_copy_engine PRIVATE USE_HIP_BACKEND=1)
+elseif(USE_L0)
+  find_path(LEVEL_ZERO_INCLUDE_DIRS level_zero/ze_api.h)
+  find_library(LEVEL_ZERO_LIB ze_loader)
+  if (NOT LEVEL_ZERO_INCLUDE_DIRS OR NOT LEVEL_ZERO_LIB)
+    message(FATAL_ERROR "Level Zero headers or loader not found")
+  endif()
+  add_library(bodocache_copy_engine MODULE copy_engine_native_l0.cpp)
+  target_compile_definitions(bodocache_copy_engine PRIVATE USE_L0_BACKEND=1)
+  target_include_directories(bodocache_copy_engine PRIVATE ${LEVEL_ZERO_INCLUDE_DIRS})
+  target_link_libraries(bodocache_copy_engine PRIVATE ${LEVEL_ZERO_LIB})
+else()
+  message(FATAL_ERROR "Select a backend: -DUSE_CUDA=ON or -DUSE_HIP=ON")
+endif()
+
+target_link_libraries(bodocache_copy_engine PRIVATE pybind11::module Python3::Module)
+
+# Python module naming (no 'lib' prefix, .so/.pyd suffix)
+set_target_properties(bodocache_copy_engine PROPERTIES
+  PREFIX ""
+  OUTPUT_NAME "bodocache_agent_copy_engine"
+)
+
+# Optional io_uring reader module
+option(USE_URING "Build io_uring reader module" OFF)
+if (USE_URING)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(LIBURING REQUIRED IMPORTED_TARGET liburing)
+  add_library(bodocache_io_uring MODULE io_uring_reader.cpp)
+  target_link_libraries(bodocache_io_uring PRIVATE PkgConfig::LIBURING pybind11::module Python3::Module)
+  set_target_properties(bodocache_io_uring PROPERTIES PREFIX "" OUTPUT_NAME "bodocache_agent_io_uring")
+endif()

--- a/native/copy_engine_common.hpp
+++ b/native/copy_engine_common.hpp
@@ -1,0 +1,250 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/functional.h>
+#include <pybind11/pytypes.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+
+struct HostBuf {
+  void* ptr{nullptr};
+  size_t bytes{0};
+};
+
+inline void* capsule_to_ptr(const py::object& obj) {
+  if (py::isinstance<py::capsule>(obj)) {
+    py::capsule cap = obj.cast<py::capsule>();
+    return cap.get_pointer();
+  }
+  // Allow int addresses as a fallback
+  if (py::isinstance<py::int_>(obj)) {
+    uintptr_t addr = obj.cast<uintptr_t>();
+    return reinterpret_cast<void*>(addr);
+  }
+  // Allow objects exposing a __int__ or __index__ (e.g., torch Tensor.data_ptr())
+  try {
+    uintptr_t addr = obj.attr("__int__")().cast<uintptr_t>();
+    return reinterpret_cast<void*>(addr);
+  } catch (...) {}
+  return nullptr;
+}
+
+inline bool get_bytes_view(const py::handle& h, void** out_ptr, size_t* out_size) {
+  // Accept memoryview or any object supporting buffer protocol
+  if (PyMemoryView_Check(h.ptr())) {
+    py::memoryview mv = py::reinterpret_borrow<py::memoryview>(h);
+    if (!mv || mv.readonly()) return false;
+    *out_ptr = mv.data();
+    *out_size = mv.nbytes();
+    return true;
+  }
+  if (PyObject_CheckBuffer(h.ptr())) {
+    py::buffer buf = py::reinterpret_borrow<py::buffer>(h);
+    py::buffer_info info = buf.request();
+    *out_ptr = info.ptr;
+    *out_size = static_cast<size_t>(info.size) * static_cast<size_t>(info.itemsize);
+    return true;
+  }
+  // Fallback: if it's bytes, we need to copy into a temp pinned buf outside
+  if (PyBytes_Check(h.ptr())) {
+    char* data;
+    Py_ssize_t len;
+    if (PyBytes_AsStringAndSize(h.ptr(), &data, &len) == 0) {
+      *out_ptr = data;
+      *out_size = static_cast<size_t>(len);
+      return true;
+    }
+  }
+  return false;
+}
+
+// Backend-agnostic engine needs to provide these functions/types:
+// - using stream_t
+// - void init_device_streams(int device, int streams_per_dev)
+// - stream_t get_stream(int device, int stream_id)
+// - void* alloc_pinned(size_t bytes)
+// - void free_pinned(void*)
+// - void memcpy_h2d_async(int device, void* dst_device, const void* src_host, size_t bytes, stream_t)
+// - void record_event(stream_t, void** out_event)
+// - bool event_completed(void* event)
+// - void destroy_event(void* event)
+
+struct PendingOp {
+  int device{0};
+  void* dst_device{nullptr};
+  void* src_host{nullptr};
+  size_t bytes{0};
+  int stream_id{0};
+  int64_t deadline_ms{0};
+  void* event{nullptr};
+};
+
+template <typename Backend>
+class CopyEngineNative {
+ public:
+  CopyEngineNative(int device_id, int streams_per_device)
+      : device_(device_id), streams_per_dev_(streams_per_device) {
+    backend_.init_device_streams(device_, streams_per_dev_);
+  }
+
+  ~CopyEngineNative() { stop_worker(); }
+
+  py::memoryview acquire_host_buffer(size_t bytes) {
+    void* p = backend_.alloc_pinned(bytes);
+    if (!p) throw std::bad_alloc();
+    std::lock_guard<std::mutex> g(mu_);
+    live_buffers_.push_back(p);
+    // Expose as writable 1D uint8 buffer
+    return py::memoryview(py::buffer_info(
+        p, sizeof(uint8_t), py::format_descriptor<uint8_t>::format(), 1, {bytes}, {sizeof(uint8_t)}));
+  }
+
+  void submit(py::list ops, py::function callback) {
+    std::vector<PendingOp> batch;
+    batch.reserve(py::len(ops));
+
+    for (auto item : ops) {
+      py::object op = py::reinterpret_borrow<py::object>(item);
+      // Extract fields by attribute or mapping
+      auto get_attr = [&](const char* name) -> py::object {
+        if (PyObject_HasAttrString(op.ptr(), name)) return op.attr(name);
+        if (PyMapping_Check(op.ptr())) return op[name];
+        throw std::runtime_error(std::string("missing field ") + name);
+      };
+      py::object src_obj = get_attr("src");
+      py::object dst_obj = get_attr("dst");
+      size_t bytes = get_attr("bytes").cast<size_t>();
+      int stream_id = 0;
+      if (PyObject_HasAttrString(op.ptr(), "stream_id")) stream_id = op.attr("stream_id").cast<int>();
+      int device = 0;
+      if (PyObject_HasAttrString(op.ptr(), "gpu_id")) device = op.attr("gpu_id").cast<int>();
+      int64_t deadline_ms = 0;
+      if (PyObject_HasAttrString(op.ptr(), "deadline_ms")) deadline_ms = op.attr("deadline_ms").cast<int64_t>();
+
+      void* src_ptr = nullptr;
+      size_t src_size = 0;
+      if (!get_bytes_view(src_obj, &src_ptr, &src_size)) {
+        throw std::runtime_error("src must be a writable buffer or bytes");
+      }
+      if (src_size < bytes) {
+        throw std::runtime_error("src buffer too small");
+      }
+      void* dst_ptr = capsule_to_ptr(dst_obj);
+      if (!dst_ptr) throw std::runtime_error("dst must be a device pointer capsule or int address");
+
+      PendingOp po;
+      po.device = device;
+      po.dst_device = dst_ptr;
+      po.src_host = src_ptr;
+      po.bytes = bytes;
+      po.stream_id = stream_id;
+      po.deadline_ms = deadline_ms;
+      batch.push_back(po);
+    }
+
+    // Submit copies
+    for (auto& po : batch) {
+      auto stream = backend_.get_stream(po.device, po.stream_id);
+      backend_.memcpy_h2d_async(po.device, po.dst_device, po.src_host, po.bytes, stream);
+      backend_.record_event(stream, &po.event);
+    }
+
+    // Start worker thread if not running
+    ensure_worker();
+
+    {
+      std::lock_guard<std::mutex> g(mu_);
+      for (auto& po : batch) pending_.push_back(std::move(po));
+      // Update the active callback (single callback used for all ops)
+      active_callback_ = callback;
+    }
+  }
+
+ private:
+  void ensure_worker() {
+    bool expected = false;
+    if (running_.compare_exchange_strong(expected, true)) {
+      worker_ = std::thread([this]() { this->worker_loop(); });
+    }
+  }
+
+  void stop_worker() {
+    bool was_running = running_.exchange(false);
+    if (was_running && worker_.joinable()) worker_.join();
+  }
+
+  void worker_loop() {
+    while (running_.load()) {
+      std::vector<PendingOp> done;
+      py::function cb;
+      {
+        std::lock_guard<std::mutex> g(mu_);
+        for (auto it = pending_.begin(); it != pending_.end();) {
+          if (backend_.event_completed(it->event)) {
+            done.push_back(*it);
+            backend_.destroy_event(it->event);
+            it = pending_.erase(it);
+          } else {
+            ++it;
+          }
+        }
+        if (!active_callback_.is_none()) cb = active_callback_.cast<py::function>();
+      }
+
+      // Fire callbacks and free host buffers (if we own them)
+      if (!done.empty()) {
+        // Identify any engine-owned host buffers to free
+        {
+          std::lock_guard<std::mutex> g(mu_);
+          for (auto& po : done) {
+            // If src_host is one of our live buffers, free it
+            auto it = std::find(live_buffers_.begin(), live_buffers_.end(), po.src_host);
+            if (it != live_buffers_.end()) {
+              backend_.free_pinned(po.src_host);
+              live_buffers_.erase(it);
+            }
+          }
+        }
+
+        if (cb) {
+          py::gil_scoped_acquire ag;
+          for (auto& po : done) {
+            try {
+              py::dict info;
+              info["gpu_id"] = po.device;
+              info["bytes"] = py::int_(po.bytes);
+              info["deadline_ms"] = py::int_(po.deadline_ms);
+              cb(info);
+            } catch (...) {
+              // Swallow exceptions to keep worker alive
+            }
+          }
+        }
+      }
+
+      // Sleep a bit
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }
+
+  Backend backend_{};
+  int device_{0};
+  int streams_per_dev_{4};
+  std::atomic<bool> running_{false};
+  std::thread worker_{};
+  std::mutex mu_;
+  std::vector<void*> live_buffers_;
+  std::vector<PendingOp> pending_;
+  py::object active_callback_ = py::none();
+};

--- a/native/copy_engine_native_cuda.cu
+++ b/native/copy_engine_native_cuda.cu
@@ -1,0 +1,76 @@
+#include "copy_engine_common.hpp"
+
+#ifdef USE_CUDA_BACKEND
+
+#include <cuda_runtime.h>
+
+struct CudaBackend {
+  using stream_t = cudaStream_t;
+  std::vector<std::vector<stream_t>> streams_; // [device][stream_id]
+
+  void init_device_streams(int device, int streams_per_dev) {
+    int device_count = 0;
+    cudaGetDeviceCount(&device_count);
+    if (device < 0 || device >= device_count) {
+      throw std::runtime_error("invalid CUDA device id");
+    }
+    cudaSetDevice(device);
+    streams_.resize(device + 1);
+    auto& vec = streams_[device];
+    vec.resize(streams_per_dev);
+    for (int i = 0; i < streams_per_dev; ++i) {
+      cudaStreamCreateWithFlags(&vec[i], cudaStreamNonBlocking);
+    }
+  }
+
+  stream_t get_stream(int device, int stream_id) {
+    if (stream_id < 0) stream_id = 0;
+    auto& vec = streams_.at(device);
+    if (vec.empty()) throw std::runtime_error("streams not initialized");
+    return vec[stream_id % static_cast<int>(vec.size())];
+  }
+
+  void* alloc_pinned(size_t bytes) {
+    void* p = nullptr;
+    cudaError_t st = cudaHostAlloc(&p, bytes, cudaHostAllocDefault);
+    if (st != cudaSuccess) return nullptr;
+    return p;
+  }
+
+  void free_pinned(void* p) { cudaFreeHost(p); }
+
+  void memcpy_h2d_async(int device, void* dst_device, const void* src_host, size_t bytes, stream_t s) {
+    cudaSetDevice(device);
+    cudaMemcpyAsync(dst_device, src_host, bytes, cudaMemcpyHostToDevice, s);
+  }
+
+  void record_event(stream_t s, void** out_event) {
+    cudaEvent_t ev;
+    cudaEventCreateWithFlags(&ev, cudaEventDisableTiming);
+    cudaEventRecord(ev, s);
+    *out_event = reinterpret_cast<void*>(ev);
+  }
+
+  bool event_completed(void* event) {
+    cudaEvent_t ev = reinterpret_cast<cudaEvent_t>(event);
+    cudaError_t q = cudaEventQuery(ev);
+    return q == cudaSuccess;
+  }
+
+  void destroy_event(void* event) {
+    cudaEvent_t ev = reinterpret_cast<cudaEvent_t>(event);
+    cudaEventDestroy(ev);
+  }
+};
+
+using CopyEngineCuda = CopyEngineNative<CudaBackend>;
+
+PYBIND11_MODULE(bodocache_agent_copy_engine, m) {
+  py::class_<CopyEngineCuda>(m, "CopyEngine")
+      .def(py::init<int, int>(), py::arg("device_id") = 0, py::arg("streams_per_device") = 4)
+      .def("acquire_host_buffer", &CopyEngineCuda::acquire_host_buffer, py::arg("bytes"))
+      .def("submit", &CopyEngineCuda::submit, py::arg("ops"), py::arg("callback"));
+}
+
+#endif // USE_CUDA_BACKEND
+

--- a/native/copy_engine_native_hip.cpp
+++ b/native/copy_engine_native_hip.cpp
@@ -1,0 +1,76 @@
+#include "copy_engine_common.hpp"
+
+#ifdef USE_HIP_BACKEND
+
+#include <hip/hip_runtime.h>
+
+struct HipBackend {
+  using stream_t = hipStream_t;
+  std::vector<std::vector<stream_t>> streams_;
+
+  void init_device_streams(int device, int streams_per_dev) {
+    int device_count = 0;
+    hipGetDeviceCount(&device_count);
+    if (device < 0 || device >= device_count) {
+      throw std::runtime_error("invalid HIP device id");
+    }
+    hipSetDevice(device);
+    streams_.resize(device + 1);
+    auto& vec = streams_[device];
+    vec.resize(streams_per_dev);
+    for (int i = 0; i < streams_per_dev; ++i) {
+      hipStreamCreateWithFlags(&vec[i], hipStreamNonBlocking);
+    }
+  }
+
+  stream_t get_stream(int device, int stream_id) {
+    if (stream_id < 0) stream_id = 0;
+    auto& vec = streams_.at(device);
+    if (vec.empty()) throw std::runtime_error("streams not initialized");
+    return vec[stream_id % static_cast<int>(vec.size())];
+  }
+
+  void* alloc_pinned(size_t bytes) {
+    void* p = nullptr;
+    hipError_t st = hipHostMalloc(&p, bytes, hipHostMallocDefault);
+    if (st != hipSuccess) return nullptr;
+    return p;
+  }
+
+  void free_pinned(void* p) { hipHostFree(p); }
+
+  void memcpy_h2d_async(int device, void* dst_device, const void* src_host, size_t bytes, stream_t s) {
+    hipSetDevice(device);
+    hipMemcpyAsync(dst_device, src_host, bytes, hipMemcpyHostToDevice, s);
+  }
+
+  void record_event(stream_t s, void** out_event) {
+    hipEvent_t ev;
+    hipEventCreateWithFlags(&ev, hipEventDisableTiming);
+    hipEventRecord(ev, s);
+    *out_event = reinterpret_cast<void*>(ev);
+  }
+
+  bool event_completed(void* event) {
+    hipEvent_t ev = reinterpret_cast<hipEvent_t>(event);
+    hipError_t q = hipEventQuery(ev);
+    return q == hipSuccess;
+  }
+
+  void destroy_event(void* event) {
+    hipEvent_t ev = reinterpret_cast<hipEvent_t>(event);
+    hipEventDestroy(ev);
+  }
+};
+
+using CopyEngineHip = CopyEngineNative<HipBackend>;
+
+PYBIND11_MODULE(bodocache_agent_copy_engine, m) {
+  py::class_<CopyEngineHip>(m, "CopyEngine")
+      .def(py::init<int, int>(), py::arg("device_id") = 0, py::arg("streams_per_device") = 4)
+      .def("acquire_host_buffer", &CopyEngineHip::acquire_host_buffer, py::arg("bytes"))
+      .def("submit", &CopyEngineHip::submit, py::arg("ops"), py::arg("callback"));
+}
+
+#endif // USE_HIP_BACKEND
+

--- a/native/copy_engine_native_l0.cpp
+++ b/native/copy_engine_native_l0.cpp
@@ -1,0 +1,123 @@
+#include "copy_engine_common.hpp"
+
+#ifdef USE_L0_BACKEND
+
+#include <level_zero/ze_api.h>
+
+struct L0Backend {
+  using stream_t = ze_command_queue_handle_t;
+  ze_context_handle_t context_{nullptr};
+  ze_device_handle_t device_{nullptr};
+  ze_event_pool_handle_t event_pool_{nullptr};
+  std::vector<stream_t> queues_;
+
+  void init_device_streams(int device_index, int streams_per_dev) {
+    zeInit(0);
+    uint32_t nDrivers = 0;
+    zeDriverGet(&nDrivers, nullptr);
+    if (nDrivers == 0) throw std::runtime_error("No Level Zero drivers found");
+    std::vector<ze_driver_handle_t> drivers(nDrivers);
+    zeDriverGet(&nDrivers, drivers.data());
+
+    // Choose first driver; enumerate devices
+    uint32_t nDevices = 0;
+    zeDeviceGet(drivers[0], &nDevices, nullptr);
+    if (nDevices == 0) throw std::runtime_error("No Level Zero devices found");
+    std::vector<ze_device_handle_t> devices(nDevices);
+    zeDeviceGet(drivers[0], &nDevices, devices.data());
+    if (device_index < 0 || (uint32_t)device_index >= nDevices) throw std::runtime_error("Invalid device index");
+    device_ = devices[device_index];
+
+    ze_context_desc_t cdesc = {ZE_STRUCTURE_TYPE_CONTEXT_DESC, nullptr, 0};
+    zeContextCreate(drivers[0], &cdesc, &context_);
+
+    // Create command queues (streams)
+    queues_.resize(streams_per_dev);
+    for (int i = 0; i < streams_per_dev; ++i) {
+      ze_command_queue_desc_t qdesc = {ZE_STRUCTURE_TYPE_COMMAND_QUEUE_DESC};
+      qdesc.ordinal = 0;
+      qdesc.flags = 0;
+      qdesc.mode = ZE_COMMAND_QUEUE_MODE_ASYNCHRONOUS;
+      qdesc.priority = ZE_COMMAND_QUEUE_PRIORITY_NORMAL;
+      zeCommandQueueCreate(context_, device_, &qdesc, &queues_[i]);
+    }
+
+    // Create an event pool
+    ze_event_pool_desc_t pdesc = {ZE_STRUCTURE_TYPE_EVENT_POOL_DESC};
+    pdesc.count = 1024;
+    pdesc.flags = ZE_EVENT_POOL_FLAG_HOST_VISIBLE;
+    zeCommandListCreate(context_, device_, nullptr, nullptr); // warmup
+    zeEventPoolCreate(context_, &pdesc, 0, nullptr, &event_pool_);
+  }
+
+  stream_t get_stream(int /*device*/, int stream_id) {
+    if (queues_.empty()) throw std::runtime_error("queues not initialized");
+    if (stream_id < 0) stream_id = 0;
+    return queues_[stream_id % static_cast<int>(queues_.size())];
+  }
+
+  void* alloc_pinned(size_t bytes) {
+    ze_host_mem_alloc_desc_t hdesc = {ZE_STRUCTURE_TYPE_HOST_MEM_ALLOC_DESC};
+    void* p = nullptr;
+    ze_result_t r = zeMemAllocHost(context_, &hdesc, bytes, /*alignment*/ 64, &p);
+    if (r != ZE_RESULT_SUCCESS) return nullptr;
+    return p;
+  }
+
+  void free_pinned(void* p) { zeMemFree(context_, p); }
+
+  void memcpy_h2d_async(int /*device*/, void* dst_device, const void* src_host, size_t bytes, stream_t q) {
+    ze_command_list_handle_t cl;
+    ze_command_list_desc_t ldesc = {ZE_STRUCTURE_TYPE_COMMAND_LIST_DESC};
+    zeCommandListCreate(context_, device_, &ldesc, &cl);
+    zeEventHostSynchronize(nullptr, 0); // no-op safety
+    zeCommandListAppendMemoryCopy(cl, dst_device, src_host, bytes, /*signal*/ nullptr, 0, nullptr);
+    zeCommandListClose(cl);
+    zeCommandQueueExecuteCommandLists(q, 1, &cl, nullptr);
+    // We don't synchronize here; events handled separately via record_event()
+    // Hold the command list reference implicitly until event signals; user should flush queue
+    zeCommandListDestroy(cl); // Allow driver to reclaim after execution
+  }
+
+  void record_event(stream_t q, void** out_event) {
+    ze_event_handle_t ev;
+    ze_event_desc_t edesc = {ZE_STRUCTURE_TYPE_EVENT_DESC};
+    static std::atomic<uint32_t> next{1};
+    edesc.index = next.fetch_add(1);
+    edesc.signal = 0;
+    edesc.wait = 0;
+    zeEventCreate(event_pool_, &edesc, &ev);
+    // Emit a barrier to signal the event after prior enqueued ops
+    ze_command_list_handle_t cl;
+    ze_command_list_desc_t ldesc = {ZE_STRUCTURE_TYPE_COMMAND_LIST_DESC};
+    zeCommandListCreate(context_, device_, &ldesc, &cl);
+    zeCommandListAppendBarrier(cl, ev, 0, nullptr);
+    zeCommandListClose(cl);
+    zeCommandQueueExecuteCommandLists(q, 1, &cl, nullptr);
+    zeCommandListDestroy(cl);
+    *out_event = reinterpret_cast<void*>(ev);
+  }
+
+  bool event_completed(void* event) {
+    ze_event_handle_t ev = reinterpret_cast<ze_event_handle_t>(event);
+    ze_result_t r = zeEventQueryStatus(ev);
+    return r == ZE_RESULT_SUCCESS;
+  }
+
+  void destroy_event(void* event) {
+    ze_event_handle_t ev = reinterpret_cast<ze_event_handle_t>(event);
+    zeEventDestroy(ev);
+  }
+};
+
+using CopyEngineL0 = CopyEngineNative<L0Backend>;
+
+PYBIND11_MODULE(bodocache_agent_copy_engine, m) {
+  py::class_<CopyEngineL0>(m, "CopyEngine")
+      .def(py::init<int, int>(), py::arg("device_id") = 0, py::arg("streams_per_device") = 4)
+      .def("acquire_host_buffer", &CopyEngineL0::acquire_host_buffer, py::arg("bytes"))
+      .def("submit", &CopyEngineL0::submit, py::arg("ops"), py::arg("callback"));
+}
+
+#endif // USE_L0_BACKEND
+

--- a/native/io_uring_reader.cpp
+++ b/native/io_uring_reader.cpp
@@ -1,0 +1,83 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/pytypes.h>
+#include <pybind11/functional.h>
+#include <pybind11/numpy.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <liburing.h>
+
+namespace py = pybind11;
+
+static ssize_t read_range_into(const std::string& path, uint64_t offset, size_t size, py::object out_buf) {
+  if (size == 0) return 0;
+  // Get writable buffer
+  void* dst = nullptr; size_t nbytes = 0;
+  if (PyMemoryView_Check(out_buf.ptr())) {
+    py::memoryview mv = py::reinterpret_borrow<py::memoryview>(out_buf);
+    if (mv.readonly()) throw std::runtime_error("buffer must be writable");
+    dst = mv.data(); nbytes = mv.nbytes();
+  } else if (PyObject_CheckBuffer(out_buf.ptr())) {
+    py::buffer buf = py::reinterpret_borrow<py::buffer>(out_buf);
+    py::buffer_info info = buf.request();
+    dst = info.ptr; nbytes = (size_t)info.size * (size_t)info.itemsize;
+  } else {
+    throw std::runtime_error("out_buf must support buffer protocol");
+  }
+  if (nbytes < size) throw std::runtime_error("out_buf too small");
+
+  int fd = ::open(path.c_str(), O_RDONLY);
+  if (fd < 0) throw std::runtime_error("open failed: " + std::string(strerror(errno)));
+
+  io_uring ring;
+  if (io_uring_queue_init(16, &ring, 0) < 0) {
+    ::close(fd);
+    throw std::runtime_error("io_uring_queue_init failed");
+  }
+
+  size_t submitted = 0;
+  char* p = reinterpret_cast<char*>(dst);
+  const size_t chunk = 1 << 20; // 1MB chunks
+  size_t remaining = size;
+  uint64_t off = offset;
+
+  while (remaining > 0) {
+    size_t to_read = remaining < chunk ? remaining : chunk;
+    io_uring_sqe* sqe = io_uring_get_sqe(&ring);
+    if (!sqe) {
+      io_uring_submit(&ring);
+      continue;
+    }
+    io_uring_prep_read(sqe, fd, p + submitted, to_read, off);
+    io_uring_sqe_set_data64(sqe, submitted + to_read);
+    io_uring_submit(&ring);
+
+    // Wait for completion of this chunk before queuing more to keep it simple
+    io_uring_cqe* cqe = nullptr;
+    int ret = io_uring_wait_cqe(&ring, &cqe);
+    if (ret < 0) {
+      io_uring_queue_exit(&ring); ::close(fd);
+      throw std::runtime_error("io_uring_wait_cqe failed");
+    }
+    if (cqe->res < 0) {
+      int err = -cqe->res;
+      io_uring_cqe_seen(&ring, cqe);
+      io_uring_queue_exit(&ring); ::close(fd);
+      throw std::runtime_error("read failed: errno " + std::to_string(err));
+    }
+    submitted += static_cast<size_t>(cqe->res);
+    io_uring_cqe_seen(&ring, cqe);
+    remaining -= to_read;
+    off += to_read;
+  }
+
+  io_uring_queue_exit(&ring);
+  ::close(fd);
+  return static_cast<ssize_t>(submitted);
+}
+
+PYBIND11_MODULE(bodocache_agent_io_uring, m) {
+  m.def("read_range_into", &read_range_into, py::arg("path"), py::arg("offset"), py::arg("size"), py::arg("out_buf"));
+}
+

--- a/scripts/microbench_copy.py
+++ b/scripts/microbench_copy.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import os
+import time
+import secrets
+
+import argparse
+
+from bodocache.adapters.segmented_file_backend import SegmentedFileBackend
+from bodocache.agent.node_agent import NodeAgent
+from bodocache.integrations.base import KVRequest
+from bodocache.integrations.vllm_adapter import VLLMBCacheAdapter
+from bodocache.agent.copy_engine import get_copy_engine
+
+
+def maybe_torch_device_ptr(nbytes: int):
+    try:
+        import torch
+        t = torch.empty((nbytes,), dtype=torch.uint8, device='cuda')
+        from bodocache.integrations.ptr import from_torch_tensor
+        return from_torch_tensor(t)
+    except Exception as e:
+        return None
+
+
+def run_once(page_bytes: int, pages: int, streams: int):
+    root = os.environ.get("BCACHE_TMP", ".bcache_tmp")
+    be = SegmentedFileBackend(root)
+    model_id, model_version, layer = "m", "v", 0
+    for pid in range(pages):
+        be.write_page(model_id, model_version, layer, pid, page_bytes, secrets.token_bytes(page_bytes))
+
+    eng = get_copy_engine(prefer_native=True)
+    agent = NodeAgent(be, page_bytes=page_bytes, copy_engine=eng)
+    adapter = VLLMBCacheAdapter(agent, node="n0", model_id=model_id, model_version=model_version, min_io_bytes=0, max_ops_per_tier=streams)
+    now_ms = int(time.time() * 1000)
+
+    req = KVRequest(
+        req_id="r0",
+        node="n0",
+        model_id=model_id,
+        model_version=model_version,
+        prefix_id="p",
+        layer=layer,
+        page_start=0,
+        page_end=pages - 1,
+        page_bytes=page_bytes,
+        tenant="t",
+        est_fill_ms=1.0,
+        tier_src=0,
+        tier_dst=2,
+        deadline_ms=now_ms + 1000,
+    )
+
+    dst = maybe_torch_device_ptr(pages * page_bytes)
+    ready = []
+    t0 = time.time()
+    res = adapter.prefetch([req], now_ms=now_ms, dest_resolver=(lambda info: dst) if dst is not None else None, on_ready=lambda info: ready.append(info))
+    dt = (time.time() - t0) * 1000.0
+    return res.exec_stats.get("bytes", 0), dt, len(ready), dst is not None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--page-bytes", type=int, default=1 << 20)
+    ap.add_argument("--pages", type=int, default=8)
+    ap.add_argument("--streams", type=int, default=4)
+    args = ap.parse_args()
+
+    bytes_copied, dt_ms, ready_events, used_device = run_once(args.page_bytes, args.pages, args.streams)
+    mode = "native" if used_device else "simulation"
+    print(f"mode={mode} bytes={bytes_copied} dt_ms={dt_ms:.3f} ready_events={ready_events}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_integration_stub.py
+++ b/scripts/run_integration_stub.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from typing import Any, Dict, Optional
+
+import yaml
+
+from bodocache.agent.copy_engine import get_copy_engine
+from bodocache.agent.node_agent import NodeAgent
+from bodocache.integrations.config import KVOverrides
+from bodocache.integrations.loader import load_callable
+from bodocache.integrations.ptr import from_torch_tensor  # noqa: F401 (hint for users)
+from bodocache.telemetry.trace import TraceRecorder
+
+
+def load_backend(root: str, use_uring: bool):
+    if use_uring:
+        try:
+            from bodocache.adapters.uring_backend import SegmentedUringBackend
+
+            return SegmentedUringBackend(root)
+        except Exception as e:
+            print(f"io_uring backend not available ({e}); falling back to file backend.")
+    from bodocache.adapters.segmented_file_backend import SegmentedFileBackend
+
+    return SegmentedFileBackend(root)
+
+
+def build_adapter(engine_name: str, agent: NodeAgent, node: str, model_id: str, model_version: str, window_ms: int):
+    if engine_name == "vllm":
+        from bodocache.integrations.vllm_adapter import VLLMBCacheAdapter
+
+        return VLLMBCacheAdapter(agent, node=node, model_id=model_id, model_version=model_version, window_ms=window_ms, trace=TraceRecorder())
+    elif engine_name == "sglang":
+        from bodocache.integrations.sglang_adapter import SGLangBCacheAdapter
+
+        return SGLangBCacheAdapter(agent, node=node, model_id=model_id, model_version=model_version, window_ms=window_ms, trace=TraceRecorder())
+    else:
+        raise ValueError(f"unknown engine: {engine_name}")
+
+
+def build_integration(engine_name: str, engine: Any, adapter, section: Dict[str, Any]):
+    kv = section.get("kv", {})
+    deadline_offset_ms = section.get("deadline_offset_ms")
+    ov = KVOverrides(
+        block_size=kv.get("block_size"),
+        num_layers=kv.get("num_layers"),
+        num_kv_heads=kv.get("num_kv_heads"),
+        head_size=kv.get("head_size"),
+        kv_dtype=kv.get("kv_dtype"),
+    )
+    collect_spec = section.get("collect_blocks")
+    dest_spec = section.get("dest_resolver")
+    collect_blocks = load_callable(collect_spec) if collect_spec else None
+    dest_resolver = load_callable(dest_spec) if dest_spec else None
+
+    if engine_name == "vllm":
+        from bodocache.integrations.vllm_integration import VLLMIntegration
+
+        return VLLMIntegration(engine, adapter, collect_blocks=collect_blocks, dest_resolver=dest_resolver, kv_overrides=ov, deadline_offset_ms=deadline_offset_ms)
+    else:
+        from bodocache.integrations.sglang_integration import SGLangIntegration
+
+        return SGLangIntegration(engine, adapter, collect_blocks=collect_blocks, dest_resolver=dest_resolver, kv_overrides=ov, deadline_offset_ms=deadline_offset_ms)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="BCache integration stub runner")
+    ap.add_argument("--engine", choices=["vllm", "sglang"], required=True)
+    ap.add_argument("--config", type=str, required=True, help="YAML config with overrides and callables")
+    ap.add_argument("--segments-root", type=str, default=".bcache_segments")
+    ap.add_argument("--node", type=str, default="n0")
+    ap.add_argument("--model-id", type=str, default="m")
+    ap.add_argument("--model-version", type=str, default="v")
+    ap.add_argument("--window-ms", type=int, default=20)
+    ap.add_argument("--prefer-native", action="store_true")
+    ap.add_argument("--io-uring", action="store_true")
+    ap.add_argument("--prefix-id", type=str, default="session")
+    args = ap.parse_args()
+
+    with open(args.config, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f) or {}
+    section = cfg.get(args.engine, {})
+    if not section:
+        print(f"Config missing section for engine '{args.engine}'.")
+        sys.exit(1)
+
+    backend = load_backend(args.segments_root, args.io_uring)
+    eng = get_copy_engine(prefer_native=args.prefer_native) if args.prefer_native else None
+    agent = NodeAgent(backend, copy_engine=eng)
+    adapter = build_adapter(args.engine, agent, args.node, args.model_id, args.model_version, args.window_ms)
+    integration = build_integration(args.engine, engine={}, adapter=adapter, section=section)
+
+    # Run a single prefetch step using provided callables. Users can adapt this to their decode loop.
+    now_ms = int(time.time() * 1000)
+    try:
+        res = integration.prefetch_step(state=None, prefix_id=args.prefix_id, now_ms=now_ms)
+    except Exception as e:
+        print(f"Prefetch failed: {e}")
+        sys.exit(2)
+    if res is None:
+        print("No collect_blocks callable provided; nothing to prefetch.")
+        return
+    metrics = res.metrics or {}
+    print(f"planned_ops={len(res.plan_df)} bytes={res.exec_stats.get('bytes', 0)} on_time_ratio={metrics.get('on_time_ratio')}\n")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/run_planner_service.py
+++ b/scripts/run_planner_service.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import argparse
+
+from bodocache.planner.service_http import serve
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", type=str, default="0.0.0.0")
+    ap.add_argument("--port", type=int, default=8080)
+    args = ap.parse_args()
+    print(f"Planner HTTP service listening on {args.host}:{args.port}")
+    serve(args.host, args.port)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/tune_prefetch.py
+++ b/scripts/tune_prefetch.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import os
+import statistics
+import time
+
+from scripts.microbench_copy import run_once
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pages", type=int, default=16)
+    ap.add_argument("--streams", type=str, default="2,4,8")
+    ap.add_argument("--page-bytes", type=str, default="524288,1048576,2097152")
+    ap.add_argument("--repeats", type=int, default=3)
+    args = ap.parse_args()
+
+    streams_list = [int(x) for x in args.streams.split(",")]
+    page_bytes_list = [int(x) for x in args.page_bytes.split(",")]
+
+    results = []
+    for streams, pb in itertools.product(streams_list, page_bytes_list):
+        timings = []
+        bytes_vals = []
+        ready_counts = []
+        used_device = None
+        for _ in range(args.repeats):
+            b, dt, ready, used = run_once(pb, args.pages, streams)
+            timings.append(dt)
+            bytes_vals.append(b)
+            ready_counts.append(ready)
+            used_device = used
+        avg_ms = statistics.mean(timings)
+        avg_bytes = statistics.mean(bytes_vals)
+        results.append({
+            "streams": streams,
+            "page_bytes": pb,
+            "pages": args.pages,
+            "avg_ms": avg_ms,
+            "avg_bytes": avg_bytes,
+            "ready_events": int(statistics.mean(ready_counts)),
+            "mode": "native" if used_device else "simulation",
+        })
+
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_adapters_agent.py
+++ b/tests/test_adapters_agent.py
@@ -20,6 +20,11 @@ def test_segmented_file_backend_rw(tmp_path):
     out = be.read_range(model_id, model_version, layer, 0, 1, page_bytes)
     assert len(out) == 2 * page_bytes
 
+    # Read into a preallocated buffer
+    buf = bytearray(2 * page_bytes)
+    n = be.read_range_into(model_id, model_version, layer, 0, 1, page_bytes, buf)
+    assert n == 2 * page_bytes
+
 
 def test_node_agent_exec(tmp_path):
     be = SegmentedFileBackend(str(tmp_path))
@@ -34,4 +39,3 @@ def test_node_agent_exec(tmp_path):
     stats = agent.execute(plan_df, model_id='m', model_version='v')
     assert stats['ops'] == 2
     assert stats['bytes'] == 4 * 4096  # two ranges of two pages each
-

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from bodocache.integrations.vllm_collectors import make_vllm_collector, make_vllm_dest_resolver
+
+
+class DummyBM:
+    def get_required_blocks(self, state):
+        return {0: [0, 1, 2], 1: [3]}
+
+
+class DummyKV:
+    class Tensor:
+        def __init__(self, addr: int):
+            self._addr = addr
+
+        def data_ptr(self):
+            return self._addr
+
+    def get_tensor_slice(self, layer, start, end):
+        return self.Tensor(1234 + layer + start + end)
+
+
+class DummyEngine:
+    def __init__(self):
+        self.block_manager = DummyBM()
+
+
+def test_collectors_vllm():
+    engine = DummyEngine()
+    collector = make_vllm_collector(engine)
+    out = collector(state=None)
+    assert 0 in out and 1 in out
+    kv = DummyKV()
+    resolver = make_vllm_dest_resolver(kv)
+    ptr = resolver({"layer": 0, "start_pid": 0, "end_pid": 2})
+    assert isinstance(ptr, object)  # capsule-like
+

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import secrets
+import time
+
+from bodocache.adapters.segmented_file_backend import SegmentedFileBackend
+from bodocache.agent.node_agent import NodeAgent
+from bodocache.integrations.base import KVRequest
+from bodocache.integrations.vllm_adapter import VLLMBCacheAdapter
+from bodocache.agent.copy_engine import SimCopyEngine
+
+
+def test_vllm_adapter_prefetch_sim(tmp_path):
+    be = SegmentedFileBackend(str(tmp_path))
+    # seed pages
+    for pid in range(8):
+        be.write_page("m", "v", 0, pid, 4096, secrets.token_bytes(4096))
+    agent = NodeAgent(be, page_bytes=4096)
+    adapter = VLLMBCacheAdapter(agent, node="n0", model_id="m", model_version="v", min_io_bytes=0)
+    now_ms = int(time.time() * 1000)
+    reqs = [
+        KVRequest(
+            req_id="r0",
+            node="n0",
+            model_id="m",
+            model_version="v",
+            prefix_id="p0",
+            layer=0,
+            page_start=0,
+            page_end=3,
+            page_bytes=4096,
+            tenant="t",
+            est_fill_ms=1.0,
+            tier_src=0,
+            tier_dst=2,
+            deadline_ms=now_ms + 1000,
+        )
+    ]
+    ready = []
+    res = adapter.prefetch(reqs, now_ms=now_ms, on_ready=lambda info: ready.append(info))
+    assert not res.plan_df.empty
+    assert res.exec_stats["bytes"] >= 4 * 4096
+    assert ready, "should receive on_ready callbacks in simulation"
+    assert res.metrics is None or 0.0 <= res.metrics.get("on_time_ratio", 1.0) <= 1.0
+
+
+def test_node_agent_with_engine_path(tmp_path):
+    be = SegmentedFileBackend(str(tmp_path))
+    # seed
+    for pid in range(2):
+        be.write_page("m", "v", 0, pid, 4096, secrets.token_bytes(4096))
+    eng = SimCopyEngine()
+    agent = NodeAgent(be, page_bytes=4096, copy_engine=eng)
+    adapter = VLLMBCacheAdapter(agent, node="n0", model_id="m", model_version="v", min_io_bytes=0)
+    now_ms = int(time.time() * 1000)
+    reqs = [KVRequest("r", "n0", "m", "v", "p", 0, 0, 1, 4096, "t", 1.0, 0, 2, now_ms + 1000)]
+    ready = []
+    # dest_resolver returns a dummy device pointer integer; SimCopyEngine doesn't deref it.
+    res = adapter.prefetch(reqs, now_ms=now_ms, dest_resolver=lambda info: 0, on_ready=lambda info: ready.append(info))
+    assert res.exec_stats["ops"] >= 1
+    assert ready, "on_ready should be called via engine path"

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import types
+import sys
+
+from bodocache.integrations.loader import load_callable
+
+
+def test_load_callable_dynamic():
+    mod = types.ModuleType("test_plugin_mod")
+    def f(x):
+        return x + 1
+    mod.f = f
+    sys.modules["test_plugin_mod"] = mod
+    fn = load_callable("test_plugin_mod:f")
+    assert fn(41) == 42
+

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from bodocache.integrations.vllm_blocks import VLLMCacheConfig
+from bodocache.integrations.config import KVOverrides, apply_kv_overrides
+
+
+def test_kv_overrides_apply():
+    cfg = VLLMCacheConfig(block_size=16, num_layers=2, num_kv_heads=8, head_size=64, kv_dtype="float16")
+    ov = KVOverrides(block_size=32, num_layers=24, kv_dtype="bfloat16")
+    out = apply_kv_overrides(cfg, ov)
+    assert out.block_size == 32
+    assert out.num_layers == 24
+    assert out.num_kv_heads == 8
+    assert out.head_size == 64
+    assert out.kv_dtype == "bfloat16"
+

--- a/tests/test_sglang_integration_dyn.py
+++ b/tests/test_sglang_integration_dyn.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import time
+from typing import Dict, List
+
+from bodocache.adapters.segmented_file_backend import SegmentedFileBackend
+from bodocache.agent.node_agent import NodeAgent
+from bodocache.integrations.sglang_adapter import SGLangBCacheAdapter
+from bodocache.integrations.sglang_integration import SGLangIntegration
+
+
+class DummyCacheConfig:
+    def __init__(self):
+        self.block_size = 16
+        self.cache_dtype = "float16"
+
+
+class DummyModelConfig:
+    def __init__(self):
+        self.num_hidden_layers = 2
+        self.hidden_size = 512
+        self.num_attention_heads = 8
+
+    def get_num_kv_heads(self):
+        return 8
+
+
+class DummyEngine:
+    def __init__(self):
+        self.cache_config = DummyCacheConfig()
+        self.model_config = DummyModelConfig()
+        self.node = "n0"
+        self.model_id = "m"
+        self.model_version = "v"
+
+
+def test_sglang_integration_prefetch(tmp_path):
+    be = SegmentedFileBackend(str(tmp_path))
+    page_bytes = 2 * 8 * 16 * 64 * 2
+    for pid in range(4):
+        be.write_page("m", "v", 0, pid, page_bytes, b"y" * page_bytes)
+    agent = NodeAgent(be, page_bytes=page_bytes)
+    adapter = SGLangBCacheAdapter(agent, node="n0", model_id="m", model_version="v", min_io_bytes=0, window_ms=20)
+    eng = DummyEngine()
+
+    def collector(state) -> Dict[int, List[int]]:
+        return {0: [0, 1, 2, 3]}
+
+    integ = SGLangIntegration(eng, adapter, collect_blocks=collector)
+    now_ms = int(time.time() * 1000)
+    res = integ.prefetch_step(state=None, prefix_id="sess", now_ms=now_ms)
+    assert res is not None
+    assert res.exec_stats["bytes"] >= 4 * page_bytes
+

--- a/tests/test_vllm_blocks.py
+++ b/tests/test_vllm_blocks.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from bodocache.integrations.vllm_blocks import VLLMCacheConfig, build_requests_from_blocks, coalesce_blocks
+
+
+def test_coalesce_blocks():
+    assert coalesce_blocks([]) == []
+    assert coalesce_blocks([1, 2, 3]) == [(1, 3)]
+    assert coalesce_blocks([1, 3, 2, 5, 6]) == [(1, 3), (5, 6)]
+
+
+def test_build_requests_from_blocks():
+    cfg = VLLMCacheConfig(block_size=16, num_layers=2, num_kv_heads=8, head_size=64, kv_dtype="float16")
+    now_ms = 1000
+    reqs = build_requests_from_blocks(
+        cfg,
+        node="n0",
+        model_id="m",
+        model_version="v",
+        tenant="t",
+        prefix_id="p",
+        layer_to_blocks={0: [0, 1, 2, 4], 1: [3]},
+        now_ms=now_ms,
+        deadline_offset_ms=20,
+    )
+    # Expect ranges: layer 0 -> (0,2) and (4,4); layer 1 -> (3,3)
+    assert len(reqs) == 3
+    pbytes = cfg.bytes_per_block()
+    for r in reqs:
+        assert r.page_bytes == pbytes
+        assert r.deadline_ms == now_ms + 20
+

--- a/tests/test_vllm_integration_dyn.py
+++ b/tests/test_vllm_integration_dyn.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import time
+from typing import Dict, List
+
+from bodocache.adapters.segmented_file_backend import SegmentedFileBackend
+from bodocache.agent.node_agent import NodeAgent
+from bodocache.integrations.vllm_adapter import VLLMBCacheAdapter
+from bodocache.integrations.vllm_integration import VLLMIntegration
+
+
+class DummyCacheConfig:
+    def __init__(self):
+        self.block_size = 16
+        self.cache_dtype = "float16"
+
+
+class DummyModelConfig:
+    def __init__(self):
+        self.num_hidden_layers = 2
+        self.hidden_size = 512
+        self.num_attention_heads = 8
+
+    def get_num_kv_heads(self):
+        return 8
+
+
+class DummyEngine:
+    def __init__(self):
+        self.cache_config = DummyCacheConfig()
+        self.model_config = DummyModelConfig()
+        self.node = "n0"
+        self.model_id = "m"
+        self.model_version = "v"
+
+
+def test_vllm_integration_prefetch(tmp_path):
+    # Seed some data
+    be = SegmentedFileBackend(str(tmp_path))
+    page_bytes = 2 * 8 * 16 * 64 * 2  # 2 * kv_heads * block_size * head_size * dtype_bytes
+    for pid in range(4):
+        be.write_page("m", "v", 0, pid, page_bytes, b"x" * page_bytes)
+    agent = NodeAgent(be, page_bytes=page_bytes)
+    adapter = VLLMBCacheAdapter(agent, node="n0", model_id="m", model_version="v", min_io_bytes=0, window_ms=20)
+
+    eng = DummyEngine()
+
+    def collector(state) -> Dict[int, List[int]]:
+        return {0: [0, 1, 2, 3]}
+
+    integ = VLLMIntegration(eng, adapter, collect_blocks=collector)
+    now_ms = int(time.time() * 1000)
+    res = integ.prefetch_step(state=None, prefix_id="sess", now_ms=now_ms)
+    assert res is not None
+    assert res.exec_stats["bytes"] >= 4 * page_bytes
+


### PR DESCRIPTION
vLLM/SGLang integration, multi‑vendor data plane, io_uring backend, and tuning

Summary
- End‑to‑end integration points for vLLM and SGLang
- Vendor‑neutral NodeAgent with optional native data plane backends (CUDA/ROCm/Level Zero)
- io_uring reader backend for higher storage throughput
- Telemetry improvements and tooling for tuning and package‑entry flows
- Simulator paths remain intact; new functionality is opt‑in

Highlights
- Integrations (vLLM/SGLang)
  - Adapters + Hooks: VLLMBCacheAdapter/VLLMHook/VLLMIntegration, SGLangBCacheAdapter/SGLangHook/SGLangIntegration
  - Dynamic KV config detection; per‑run overrides (KVOverrides, YAML)
  - Pluggable callables (collector/resolver) via load_callable("module:function")
  - Eviction/admission callbacks; per‑window on_time_ratio; optional JSONL per‑op trace
- Data Plane
  - Native copy engines: CUDA, ROCm/HIP, Intel Level Zero (CMake flags USE_CUDA|USE_HIP|USE_L0)
  - Pinned host buffers (acquire_host_buffer), multi‑stream async H2D (submit(ops, cb)), event‑driven callbacks
  - NodeAgent zero‑copy staging; simulator fallback preserved
- Storage
  - io_uring native module + Python backend to read segments directly into pinned buffers (USE_URING)
- Tooling
  - Tuning: scripts/tune_prefetch.py and scripts/microbench_copy.py
  - YAML‑driven stub runner: scripts/run_integration_stub.py
  - Lightweight HTTP planner service mirroring proto: scripts/run_planner_service.py
- Docs
  - docs/integrations.md, docs/vllm_integration.md, docs/sglang_integration.md
  - configs/integration_overrides.example.yaml

Build Notes
- Native engines:
  - CUDA: cmake -S native -B build-cuda -DUSE_CUDA=ON && cmake --build build-cuda -j
  - ROCm/HIP: cmake -S native -B build-hip -DUSE_HIP=ON && cmake --build build-hip -j
  - Intel L0: cmake -S native -B build-l0 -DUSE_L0=ON && cmake --build build-l0 -j
- io_uring: add -DUSE_URING=ON (requires liburing dev package)

Usage
- Integrate with vLLM/SGLang via *Integration.prefetch_step(state, prefix_id, now_ms, ...)
- Provide per‑run overrides and callable specs in YAML (collect_blocks, dest_resolver)
- Stub runner example:
  python scripts/run_integration_stub.py --engine vllm --config configs/integration_overrides.example.yaml --segments-root /path/to/segments --prefer-native

Compatibility and Safety
- Backwards compatible: simulator remains default; native backends optional
- Pinned buffer lifecycle handled (free on copy completion)
- Optional hooks wrapped; execution errors bubble clearly

Tests
- 20 tests pass locally (pure‑Python mode)
- Coverage: adapters, integrations, collectors, overrides, loader, NodeAgent, planner

Follow‑ups (separate PRs)
- Pinned buffer pooling; io_uring pipelining (higher QD)
- Per‑vendor tuning defaults (streams/min I/O/window)
- gRPC control plane and Prometheus telemetry
