### PR TITLE
Align WaveSpec contract with bw-runtime adapter

### DIFF
--- a/bodocache/adapters/__init__.py
+++ b/bodocache/adapters/__init__.py
@@ -1,5 +1,8 @@
+from .bwrt_adapter import BwRuntimeAdapter  # noqa: F401
+
 __all__ = [
     "file_backend",
     "segmented_file_backend",
+    "bwrt_adapter",
+    "BwRuntimeAdapter",
 ]
-

--- a/bodocache/adapters/bwrt_adapter.py
+++ b/bodocache/adapters/bwrt_adapter.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from typing import Any, Iterable, Sequence
+
+try:  # pragma: no cover - optional fast path
+    from bwrt import _bwrt as bw  # type: ignore
+    _HAVE_PYBIND = True
+except Exception:  # pragma: no cover - optional fast path
+    bw = None  # type: ignore
+    _HAVE_PYBIND = False
+
+if not _HAVE_PYBIND:
+    try:  # pragma: no cover - optional fallback
+        from bwrt.runtime import BwRuntime as _BwRt  # type: ignore
+        from bwrt.wavespec_adapter import (  # type: ignore
+            wavespec_from_dict as _ws_from_dict,
+            wavespec_from_proto as _ws_from_proto,
+        )
+        _HAVE_CTYPES = True
+    except Exception:  # pragma: no cover - runtime not installed
+        _BwRt = None  # type: ignore
+        _ws_from_dict = _ws_from_proto = None  # type: ignore
+        _HAVE_CTYPES = False
+else:
+    _BwRt = None  # type: ignore
+    _ws_from_dict = _ws_from_proto = None  # type: ignore
+    _HAVE_CTYPES = False
+
+
+def _ptr_from_obj(obj: Any) -> int:
+    if isinstance(obj, int):
+        return obj
+    ai = getattr(obj, "__array_interface__", None) or getattr(obj, "array_interface", None)
+    if ai and "data" in ai:
+        return int(ai["data"][0])
+    cai = getattr(obj, "__cuda_array_interface__", None) or getattr(obj, "cuda_array_interface", None)
+    if cai and "data" in cai:
+        data = cai["data"][0]
+        if isinstance(data, (tuple, list)):
+            return int(data[0])
+        return int(data)
+    buf = getattr(obj, "data", None)
+    if buf is not None and hasattr(buf, "ptr"):
+        return int(buf.ptr)
+    raise TypeError(
+        "Provide int pointer, NumPy/CuPy array, or object with array_interface/cuda_array_interface"
+    )
+
+
+def _normalise_tile_order(to_seq: Any) -> List[Tuple[int, int]] | None:
+    if to_seq is None:
+        return None
+    if isinstance(to_seq, (list, tuple)):
+        out: List[Tuple[int, int]] = []
+        for item in to_seq:
+            if isinstance(item, (list, tuple)) and len(item) == 2:
+                out.append((int(item[0]), int(item[1])))
+            else:
+                try:
+                    # Treat as flattened index; decode later if runtime provides dims.
+                    idx = int(item)
+                    out.append((idx, 0))
+                except Exception:  # pragma: no cover - defensive
+                    continue
+        return out
+    return None
+
+
+def _flatten_tile_order(tile_pairs: List[Tuple[int, int]] | None) -> List[int] | None:
+    if not tile_pairs:
+        return None
+    return [int(r) << 16 | int(c) for r, c in tile_pairs]
+
+
+class BwRuntimeAdapter:
+    """Thin wrapper that normalises bw-runtime's pybind / ctypes APIs."""
+
+    def __init__(self, device_index: int = 0) -> None:
+        if _HAVE_PYBIND:
+            self._fast = True
+            self._runtime = bw.Runtime(device_index)  # type: ignore[attr-defined]
+        elif _HAVE_CTYPES:
+            self._fast = False
+            self._runtime = _BwRt(device_index=device_index)  # type: ignore[operator]
+        else:
+            raise RuntimeError(
+                "bwrt runtime is not installed; install bwrt wheel with either pybind or ctypes backend"
+            )
+
+    def _to_spec(self, spec_any: Any):
+        if _HAVE_PYBIND:
+            if isinstance(spec_any, dict):
+                bm = int(spec_any.get("bm", 0))
+                bn = int(spec_any.get("bn", 0))
+                bk = int(spec_any.get("bk", 0))
+                cluster = spec_any.get("cluster_shape", (1, 1))
+                cx, cy = int(cluster[0]), int(cluster[1])
+                swap_window = spec_any.get("swap_window", (0, 1))
+                sb, se = int(swap_window[0]), int(swap_window[1])
+                tile_pairs = _normalise_tile_order(spec_any.get("tile_order"))
+                pack_order = [int(x) for x in spec_any.get("pack_order", [])]
+                tmem = spec_any.get("tmem_layout", {})
+                io_extents = spec_any.get("io_extents", [])
+            else:
+                bm = int(spec_any.bm)
+                bn = int(spec_any.bn)
+                bk = int(spec_any.bk)
+                cluster = getattr(spec_any, "cluster_shape", (getattr(spec_any, "cluster_x", 1), getattr(spec_any, "cluster_y", 1)))
+                cx, cy = int(cluster[0]), int(cluster[1])
+                swap_window = getattr(spec_any, "swap_window", (getattr(spec_any, "swap_begin", 0), getattr(spec_any, "swap_end", 1)))
+                sb, se = int(swap_window[0]), int(swap_window[1])
+                tile_pairs = _normalise_tile_order(getattr(spec_any, "tile_order", None))
+                if not tile_pairs:
+                    tile_pairs = _normalise_tile_order(getattr(spec_any, "tile_order_flat", None))
+                pack_order = [int(x) for x in getattr(spec_any, "pack_order", [])]
+                tmem = getattr(spec_any, "tmem_layout", {})
+                io_extents = getattr(spec_any, "io_extents", [])
+            spec = bw.WaveSpec()  # type: ignore[attr-defined]
+            spec.bm, spec.bn, spec.bk = bm, bn, bk
+            if hasattr(spec, "cluster_shape"):
+                spec.cluster_shape = (cx, cy)
+            if hasattr(spec, "cluster_x"):
+                spec.cluster_x, spec.cluster_y = cx, cy
+            spec.swap_begin, spec.swap_end = sb, se
+            if hasattr(spec, "swap_window"):
+                spec.swap_window = (sb, se)
+            if hasattr(spec, "pack_order"):
+                spec.pack_order = pack_order
+            tile_flat = _flatten_tile_order(tile_pairs)
+            if hasattr(spec, "tile_order") and tile_pairs is not None:
+                spec.tile_order = [(int(r), int(c)) for r, c in tile_pairs]  # type: ignore[attr-defined]
+            elif hasattr(spec, "tile_order_flat") and tile_flat is not None:
+                spec.tile_order_flat = tile_flat  # type: ignore[attr-defined]
+            if hasattr(spec, "tmem_columns") and isinstance(tmem, dict):
+                spec.tmem_columns = int(tmem.get("columns", 0))
+                spec.tmem_phases = int(tmem.get("phases", 0))
+                spec.tmem_double_buffer = bool(tmem.get("double_buffer", False))
+            if hasattr(spec, "tmem_layout") and isinstance(tmem, dict):
+                spec.tmem_layout = tmem  # type: ignore[attr-defined]
+            if hasattr(spec, "io_extents"):
+                spec.io_extents = list(io_extents)
+            return spec
+        if isinstance(spec_any, dict):
+            if not _HAVE_CTYPES:
+                raise RuntimeError("bwrt ctypes adapter unavailable; install bwrt runtime")
+            cluster = spec_any.get("cluster_shape", (spec_any.get("cluster_x", 1), spec_any.get("cluster_y", 1)))
+            swap_window = spec_any.get("swap_window", (spec_any.get("swap_begin", 0), spec_any.get("swap_end", 1)))
+            enriched = dict(spec_any)
+            enriched.setdefault("cluster_x", int(cluster[0]))
+            enriched.setdefault("cluster_y", int(cluster[1]))
+            enriched.setdefault("swap_begin", int(swap_window[0]))
+            enriched.setdefault("swap_end", int(swap_window[1]))
+            tile_flat = _flatten_tile_order(_normalise_tile_order(spec_any.get("tile_order")))
+            if tile_flat and "tile_order_flat" not in enriched:
+                enriched["tile_order_flat"] = tile_flat
+            return _ws_from_dict(enriched)  # type: ignore[misc]
+        if not _HAVE_CTYPES:
+            raise RuntimeError("bwrt ctypes adapter unavailable; install bwrt runtime")
+        return _ws_from_proto(spec_any)  # type: ignore[misc]
+
+    def submit_and_wait(self, wavespec_any: Any, A: Any, B: Any, C: Any):
+        spec = self._to_spec(wavespec_any)
+        if self._fast:
+            evt = self._runtime.submit_wave(spec, A, B, C)
+            self._runtime.wait(evt, 0)
+            return self._runtime.sample()
+        a_ptr = _ptr_from_obj(A)
+        b_ptr = _ptr_from_obj(B)
+        c_ptr = _ptr_from_obj(C)
+        evt = self._runtime.submit_wave(spec, a_ptr, b_ptr, c_ptr)
+        self._runtime.wait(evt)
+        return self._runtime.sample()
+
+    def set_weights(self, weights: Any) -> None:
+        if self._fast:
+            self._runtime.set_weights(weights)
+            return
+        w_ptr = _ptr_from_obj(weights)
+        self._runtime.set_weights(w_ptr)
+
+
+__all__: Iterable[str] = ("BwRuntimeAdapter", "_ptr_from_obj")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke test
+    import numpy as np
+
+    adapter = BwRuntimeAdapter()
+    spec = {
+        "pack_order": [0, 1],
+        "tile_order": [(0, 0)],
+        "bm": 2,
+        "bn": 2,
+        "bk": 2,
+        "cluster_shape": (1, 1),
+        "tmem_layout": {"columns": 1, "phases": 1, "double_buffer": False, "stage_n": 1},
+        "io_extents": [("0", 0, 0)],
+        "swap_window": (0, 3),
+    }
+    A = np.array([[1, 2], [3, 4]], dtype=np.float32, order="C")
+    B = np.array([[5, 6], [7, 8]], dtype=np.float32, order="C")
+    C = np.zeros((2, 2), dtype=np.float32, order="C")
+    metrics = adapter.submit_and_wait(spec, A, B, C)
+    print("C:", C)
+    if metrics is not None:
+        for field in ("wgmma_active", "tma_occ", "l2_hit"):
+            print(field, getattr(metrics, field, None))

--- a/bodocache/planner/waves.py
+++ b/bodocache/planner/waves.py
@@ -1,0 +1,281 @@
+from __future__ import annotations
+
+from typing import List, Tuple, TypedDict, Optional, NamedTuple, Sequence
+
+import math
+import pandas as pd
+
+
+class TMemLayout(TypedDict):
+    columns: int
+    phases: int
+    double_buffer: bool
+    stage_n: int
+
+
+class WaveSpec(TypedDict):
+    """Runtime contract for a single execution wave."""
+
+    pack_order: List[int]
+    tile_order: List[Tuple[int, int]]
+    bm: int
+    bn: int
+    bk: int
+    cluster_shape: Tuple[int, int]
+    tmem_layout: TMemLayout
+    io_extents: List[Tuple[str, int, int]]
+    swap_window: Tuple[int, int]
+
+
+class TileConfig(NamedTuple):
+    bm: int
+    bn: int
+    bk: int
+    stage: int
+    cluster: Tuple[int, int]
+
+
+# A curated whitelist of tiles mirrored by bw-runtime. Update in lock-step with runtime.
+DEFAULT_TILE_CONFIGS: Tuple[TileConfig, ...] = (
+    TileConfig(128, 128, 64, 2, (2, 1)),
+    TileConfig(128, 256, 64, 2, (2, 1)),
+    TileConfig(256, 128, 64, 2, (2, 1)),
+    TileConfig(128, 128, 128, 3, (2, 1)),
+)
+
+
+def _resolve_whitelist(whitelist: Optional[Sequence[TileConfig]]) -> Tuple[TileConfig, ...]:
+    if whitelist and len(whitelist):
+        return tuple(whitelist)
+    return DEFAULT_TILE_CONFIGS
+
+
+def _dtype_bytes(dtype: str) -> int:
+    d = dtype.lower()
+    if d in ("float16", "fp16", "bfloat16", "bf16"):
+        return 2
+    if d in ("float32", "fp32"):
+        return 4
+    # default conservative
+    return 2
+
+
+def _ensure_tile_whitelist(
+    dtype: str,
+    configs: Sequence[TileConfig],
+) -> TileConfig:
+    """Return the first tile config that satisfies dtype granularity requirements."""
+
+    if not configs:
+        raise ValueError("Tile whitelist is empty; cannot select WaveSpec shape.")
+
+    bpe = _dtype_bytes(dtype)
+    for cfg in configs:
+        if (cfg.bk * bpe) % 32 == 0:
+            return cfg
+
+    raise ValueError(
+        f"No tile config satisfies 32B K granularity for dtype={dtype};"
+        " provide a whitelist with compliant bk values."
+    )
+
+
+def _select_tile_config(
+    dtype: str,
+    *,
+    shapes: Optional[List[Tuple[int, int, int]]] = None,
+    whitelist: Optional[Sequence[TileConfig]] = None,
+    default_cluster: Tuple[int, int] = (2, 1),
+    default_stage: int = 2,
+) -> TileConfig:
+    """Pick a tile configuration for the wave respecting the whitelist contract."""
+
+    if whitelist and len(whitelist):
+        return _ensure_tile_whitelist(dtype, whitelist)
+
+    if shapes:
+        converted = tuple(
+            TileConfig(int(bm), int(bn), int(bk), int(default_stage), (int(default_cluster[0]), int(default_cluster[1])))
+            for bm, bn, bk in shapes
+        )
+        return _ensure_tile_whitelist(dtype, converted)
+
+    return _ensure_tile_whitelist(dtype, DEFAULT_TILE_CONFIGS)
+
+
+def validate_wave_spec(
+    spec: WaveSpec,
+    *,
+    dtype: str = "float16",
+    whitelist: Optional[Sequence[TileConfig]] = None,
+) -> None:
+    """Raise ValueError if the wave spec violates the runtime contract."""
+
+    required = [
+        "pack_order",
+        "tile_order",
+        "bm",
+        "bn",
+        "bk",
+        "cluster_shape",
+        "tmem_layout",
+        "io_extents",
+        "swap_window",
+    ]
+    for field in required:
+        if field not in spec:
+            raise ValueError(f"WaveSpec missing required field '{field}'")
+
+    whitelist_lookup = _resolve_whitelist(whitelist)
+    bm = int(spec["bm"])
+    bn = int(spec["bn"])
+    bk = int(spec["bk"])
+    cx, cy = (int(spec["cluster_shape"][0]), int(spec["cluster_shape"][1]))
+
+    layout = spec["tmem_layout"]
+    for key in ("columns", "phases", "double_buffer", "stage_n"):
+        if key not in layout:
+            raise ValueError(f"tmem_layout missing '{key}' field")
+    stage_n = int(layout.get("stage_n", -1))
+
+    matched = False
+    for cfg in whitelist_lookup:
+        if (
+            bm == cfg.bm
+            and bn == cfg.bn
+            and bk == cfg.bk
+            and cx == cfg.cluster[0]
+            and cy == cfg.cluster[1]
+            and stage_n == cfg.stage
+        ):
+            matched = True
+            break
+
+    if not matched:
+        raise ValueError(
+            "WaveSpec shape/cluster not in whitelist; ensure planner uses shared tile list"
+        )
+
+    bpe = _dtype_bytes(dtype)
+    if (bk * bpe) % 32 != 0:
+        raise ValueError(
+            f"WaveSpec bk={spec['bk']} fails tensor core granularity for dtype={dtype}"
+        )
+
+    sb, se = spec["swap_window"]
+    if int(sb) < 0 or int(se) <= int(sb):
+        raise ValueError(
+            f"Invalid swap window ({sb}, {se}); must satisfy 0 <= begin < end"
+        )
+
+
+def _build_swizzle(rows: int, cols: int) -> List[Tuple[int, int]]:
+    """Simple 2D swizzle: row-major with odd-row reversal (snake)."""
+    order: List[Tuple[int, int]] = []
+    for r in range(rows):
+        if r % 2 == 0:
+            for c in range(cols):
+                order.append((r, c))
+        else:
+            for c in reversed(range(cols)):
+                order.append((r, c))
+    return order
+
+
+def _factorize_req_ids(req_col: pd.Series) -> List[int]:
+    try:
+        return [int(x) for x in req_col.tolist()]
+    except Exception:
+        codes, _ = pd.factorize(req_col.astype(str), sort=False)
+        return [int(x) for x in codes.tolist()]
+
+
+def build_wave_specs(
+    plan_df: pd.DataFrame,
+    requests_df: pd.DataFrame,
+    *,
+    window_ms: int,
+    dtype: str = "float16",
+    shapes: Optional[List[Tuple[int, int, int]]] = None,
+    default_cluster: Tuple[int, int] = (2, 1),
+    tile_configs: Optional[Sequence[TileConfig]] = None,
+) -> List[WaveSpec]:
+    """Derive one WaveSpec per (node, tier_dst) group from a plan.
+
+    - pack_order favors grouping by pcluster then earliest deadlines
+    - tile_order encodes a snake swizzle over a tile grid sized to op count
+    - bm/bn/bk (plus stage_hint/cluster) are selected from a whitelist satisfying 32B K granularity
+    - io_extents reflect the coalesced ranges from the plan
+    - swap_window guards weight swaps to the post-prefetch region of the wave
+    """
+    if plan_df is None or len(plan_df) == 0:
+        return []
+
+    cfg = _select_tile_config(
+        dtype,
+        shapes=shapes,
+        whitelist=tile_configs,
+        default_cluster=default_cluster,
+    )
+    tmem_layout: TMemLayout = {
+        "columns": 8,
+        "phases": 4,
+        "double_buffer": True,
+        "stage_n": int(cfg.stage),
+    }
+    waves: List[WaveSpec] = []
+    by = [c for c in ["node", "tier_dst"] if c in plan_df.columns]
+    for _, g in (plan_df.groupby(by, sort=False) if by else [(None, plan_df)]):
+        # io_extents: one per planned coalesced op
+        io_extents: List[Tuple[str, int, int]] = []
+        for r in g.itertuples(index=False):
+            layer = int(getattr(r, "layer", 0))
+            start_pid = int(getattr(r, "start_pid", 0))
+            end_pid = int(getattr(r, "end_pid", -1))
+            if end_pid >= start_pid:
+                io_extents.append((str(layer), start_pid, end_pid))
+
+        # pack_order: use request ids, grouped by pcluster when available
+        if not requests_df.empty:
+            req = requests_df.copy()
+            # Limit to layers participating in this group to keep relevance
+            if "layer" in req.columns and "layer" in g.columns:
+                layers = set(int(x) for x in g["layer"].unique().tolist())
+                req = req[req["layer"].isin(layers)]
+            sort_cols = [c for c in ["pcluster", "deadline_ms"] if c in req.columns]
+            if sort_cols:
+                ascending = [True] * len(sort_cols)
+                req = req.sort_values(by=sort_cols, ascending=ascending)
+            pack_order = _factorize_req_ids(req.get("req_id", pd.Series(range(len(req)))))
+        else:
+            pack_order = []
+
+        # tile grid sized to op count (sqrt heuristic)
+        tiles = max(1, len(io_extents))
+        rows = int(math.floor(math.sqrt(tiles)))
+        cols = int(math.ceil(tiles / max(1, rows)))
+        # ensure full coverage
+        if rows * cols < tiles:
+            rows = max(rows, 1)
+            while rows * cols < tiles:
+                cols += 1
+        tile_order = _build_swizzle(rows, cols)[:tiles]
+
+        prefetch_tokens = int(len(io_extents))
+        compute_tiles = int(max(1, len(tile_order)))
+        swap_window = (prefetch_tokens, prefetch_tokens + compute_tiles)
+
+        wave: WaveSpec = {
+            "pack_order": pack_order,
+            "tile_order": tile_order,
+            "bm": int(cfg.bm),
+            "bn": int(cfg.bn),
+            "bk": int(cfg.bk),
+            "cluster_shape": (int(cfg.cluster[0]), int(cfg.cluster[1])),
+            "tmem_layout": dict(tmem_layout),
+            "io_extents": io_extents,
+            "swap_window": swap_window,
+        }
+        validate_wave_spec(wave, dtype=dtype, whitelist=tile_configs)
+        waves.append(wave)
+    return waves

--- a/docs/bwrt_integration.md
+++ b/docs/bwrt_integration.md
@@ -1,0 +1,144 @@
+# BCache ↔ bw-runtime Integration Handoff
+
+**Summary**
+
+Goal: Let BCache emit a WaveSpec that bw-runtime executes via a narrow ABI, while hotweights coordinates swap-safe weight updates. Keep BCache’s planner and data plane; bw-runtime provides a GPU-ready device runtime with CPU fallback for now.
+
+This handoff document captures the actionable asks, adapter code, proto schema, tests, and acceptance criteria that mirror the upstream bw-runtime change set (https://github.com/strangeloopcanon/bw-runtime).
+
+---
+
+## Planner Requirements
+
+1. **Enforce K granularity**  
+   Only emit shapes where K meets tensor-core granularity (e.g., BF16/FP16 → `K * dtype_bytes % 32 == 0`).
+
+2. **Tile/cluster whitelist**  
+   Use a tuned shortlist of `(BM, BN, BK, StageN, cluster)` entries. bw-runtime mirrors this list and asserts on it.
+
+3. **Swap windows**  
+   Emit `swap_begin ≤ token < swap_end` aligned to wave boundaries. Avoid swap windows that intersect the heavy TMA portion of a wave.
+
+4. **Swizzle metadata**  
+   Preferred: emit a concrete traversal via `tile_order_flat` (flattened `(m, n)` tile pairs).  
+   Fallback: provide a coarse swizzle knob (e.g., `swizzle_group_size`) so runtime can synthesize a traversal.
+
+5. **Planned field additions (next pass)**  
+   - dtype and tensor strides (TMA descriptor hints)  
+   - tail policy for partial tiles (pad / drop / peel)  
+   - stage hint override (runtime may downgrade if unsafe)
+
+---
+
+## WaveSpec Contract (MVP)
+
+Fields to emit **now**:
+
+- `pack_order`: request ids ordered for L2 reuse.
+- `tile_order`: list of `(tile_m, tile_n)` pairs defining thread-block swizzle.
+- `bm`, `bn`, `bk`: tile shape satisfying tensor-core granularity.
+- `cluster_shape`: `(x, y)` CTA cluster.
+- `tmem_layout`: dict with `{columns, phases, double_buffer, stage_n}`.
+- `io_extents`: list of `(layer:str, start_pid:int, end_pid:int)` ranges.
+- `swap_window`: `(begin:int, end:int)` tokens where swap is safe.
+
+### Reference Proto (`proto/bwrt/wavespec.proto`)
+
+```proto
+syntax = "proto3";
+package bwrt;
+
+message TileCoord {
+  int32 m = 1;
+  int32 n = 2;
+}
+
+message ClusterShape {
+  int32 x = 1;
+  int32 y = 2;
+}
+
+message TMemLayout {
+  int32 columns = 1;
+  int32 phases = 2;
+  bool double_buffer = 3;
+  int32 stage_n = 4;
+}
+
+message IoExtent {
+  string layer = 1;
+  int32 start_pid = 2;
+  int32 end_pid = 3;
+}
+
+message WaveSpec {
+  repeated int32 pack_order = 1;
+  repeated TileCoord tile_order = 2;
+
+  int32 bm = 3;
+  int32 bn = 4;
+  int32 bk = 5;
+
+  ClusterShape cluster_shape = 6;
+  TMemLayout tmem_layout = 7;
+  repeated IoExtent io_extents = 8;
+
+  int32 swap_begin = 9; // inclusive
+  int32 swap_end   = 10; // exclusive
+}
+```
+
+To regenerate Python stubs:
+
+```bash
+python -m pip install protobuf grpcio-tools
+python -m grpc_tools.protoc -I proto --python_out=. proto/bwrt/wavespec.proto
+```
+
+---
+
+## Runtime Adapter (Python)
+
+`bodocache/adapters/bwrt_adapter.py` provides the production adapter. It:
+
+- Prefers the pybind11 module (`bwrt._bwrt`) when present, else falls back to the ctypes binding.
+- Normalises `tile_order` pairs, `cluster_shape`, and `swap_window` into the layout expected by each runtime flavour (adding legacy fields like `swap_begin`/`swap_end` for ctypes).
+- Accepts raw device pointers or NumPy/CuPy/Torch arrays via `_ptr_from_obj`.
+- Exposes `submit_and_wait` and `set_weights`, mirroring the runtime contract.
+
+---
+
+## Validation & Instrumentation
+
+- Consume runtime metrics on each wave (or every N waves) to tune planner policies:  
+  - low `wgmma_active` → consider larger `BM/BN`  
+  - low `tma_occ` → increase prefetch/coalesced extents  
+  - low `l2_hit` → widen swizzle group or emit richer `tile_order_flat`
+- Keep ring occupancy moderate (~30–60%) to avoid TMA backpressure starving WGMMA.
+- Share whitelist updates so runtime can assert on identical sets.
+
+---
+
+## Minimal Tests To Add
+
+1. **Valid WaveSpec executes** (CPU mode): given `{bm,bn,bk,cluster_x/y,swap_begin/end}` with valid K + whitelist shape → `submit_and_wait` succeeds and produces correct `C` matrix.
+2. **Swap window enforcement:** `set_weights` succeeds inside window; fails outside after a tight window is emitted.
+3. **Invalid K rejected:** planner rejects / raises on non-granular K and falls back to a valid shape.
+
+---
+
+## Acceptance Criteria
+
+- Valid WaveSpecs pass validation; invalid ones fail fast with descriptive errors.
+- Swap windows enforced by bw-runtime; planner emits windows aligned to wave boundaries.
+- Metrics are ingested and logged for planner feedback (mocked or real).
+- Only whitelisted shapes are used (planner asserts; runtime asserts).
+
+---
+
+## Notes
+
+- The runtime package exposes both a ctypes wrapper and an optional pybind11 module. The adapter prefers pybind11 automatically when available.
+- Environment variables:
+  - `BWRT_LIB_PATH` → shared library search path when ctypes is used.
+- Planned follow-up request will extend the contract with dtype/stride metadata once device bring-up begins.

--- a/proto/bwrt/wavespec.proto
+++ b/proto/bwrt/wavespec.proto
@@ -1,0 +1,42 @@
+syntax = "proto3";
+
+package bwrt;
+
+message TileCoord {
+  int32 m = 1;
+  int32 n = 2;
+}
+
+message ClusterShape {
+  int32 x = 1;
+  int32 y = 2;
+}
+
+message TMemLayout {
+  int32 columns = 1;
+  int32 phases = 2;
+  bool double_buffer = 3;
+  int32 stage_n = 4;
+}
+
+message IoExtent {
+  string layer = 1;
+  int32 start_pid = 2;
+  int32 end_pid = 3;
+}
+
+message WaveSpec {
+  repeated int32 pack_order = 1;
+  repeated TileCoord tile_order = 2;
+
+  int32 bm = 3;
+  int32 bn = 4;
+  int32 bk = 5;
+
+  ClusterShape cluster_shape = 6;
+  TMemLayout tmem_layout = 7;
+  repeated IoExtent io_extents = 8;
+
+  int32 swap_begin = 9; // inclusive
+  int32 swap_end   = 10; // exclusive
+}

--- a/tests/test_bwrt_adapter.py
+++ b/tests/test_bwrt_adapter.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from bodocache.adapters import bwrt_adapter
+
+
+def test_ptr_from_obj_numpy():
+    arr = np.arange(4, dtype=np.float32)
+    ptr = bwrt_adapter._ptr_from_obj(arr)
+    assert isinstance(ptr, int)
+    assert ptr == arr.__array_interface__["data"][0]
+
+
+def test_bwrt_adapter_ctypes_path(monkeypatch):
+    adapter_module = importlib.reload(bwrt_adapter)
+
+    class _StubRuntime:
+        def __init__(self, device_index: int = 0) -> None:
+            self.device_index = device_index
+            self.submissions = []
+            self.waits = []
+            self.last_weight = None
+
+        def submit_wave(self, spec, a_ptr, b_ptr, c_ptr):
+            self.submissions.append((spec, a_ptr, b_ptr, c_ptr))
+            return SimpleNamespace(handle=1)
+
+        def wait(self, evt, timeout: int | None = None):
+            self.waits.append((evt, timeout))
+
+        def sample(self):
+            return {"ok": True}
+
+        def set_weights(self, ptr):
+            self.last_weight = ptr
+
+    monkeypatch.setattr(adapter_module, "_HAVE_PYBIND", False, raising=False)
+    monkeypatch.setattr(adapter_module, "_HAVE_CTYPES", True, raising=False)
+    monkeypatch.setattr(adapter_module, "_BwRt", _StubRuntime, raising=False)
+    monkeypatch.setattr(adapter_module, "_ws_from_dict", lambda spec: spec, raising=False)
+    monkeypatch.setattr(adapter_module, "_ws_from_proto", lambda spec: spec, raising=False)
+
+    adapter = adapter_module.BwRuntimeAdapter(device_index=3)
+    spec = {
+        "pack_order": [1, 2],
+        "tile_order": [(0, 0), (0, 1)],
+        "bm": 128,
+        "bn": 128,
+        "bk": 64,
+        "cluster_shape": (2, 1),
+        "tmem_layout": {"columns": 8, "phases": 4, "double_buffer": True, "stage_n": 2},
+        "io_extents": [("0", 0, 1)],
+        "swap_window": (0, 4),
+    }
+    metrics = adapter.submit_and_wait(spec, 1, 2, 3)
+    assert metrics == {"ok": True}
+    runtime = adapter._runtime  # type: ignore[attr-defined]
+    assert runtime.device_index == 3
+    assert runtime.submissions[0][0]["bm"] == 128
+    adapter.set_weights(99)
+    assert runtime.last_weight == 99
+
+
+def test_bwrt_adapter_raises_when_runtime_missing(monkeypatch):
+    adapter_module = importlib.reload(bwrt_adapter)
+    monkeypatch.setattr(adapter_module, "_HAVE_PYBIND", False, raising=False)
+    monkeypatch.setattr(adapter_module, "_HAVE_CTYPES", False, raising=False)
+    with pytest.raises(RuntimeError):
+        adapter_module.BwRuntimeAdapter()

--- a/tests/test_waves.py
+++ b/tests/test_waves.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import time
+
+import pandas as pd
+
+from bodocache.planner.scheduler import run_window
+import pytest
+
+from bodocache.planner.waves import (
+    TileConfig,
+    build_wave_specs,
+    validate_wave_spec,
+)
+from bodocache.sim.utils import (
+    synthetic_requests,
+    synthetic_heat,
+    synthetic_tier_caps,
+    synthetic_tenant_caps,
+    synthetic_layer_lat,
+)
+
+
+def test_build_wave_specs_basic():
+    now_ms = int(time.time() * 1000)
+    req = synthetic_requests(n_req=32, n_layers=4)
+    heat = synthetic_heat(req)
+    tiers = synthetic_tier_caps()
+    lats = synthetic_layer_lat(n_layers=4)
+    tenant_caps = synthetic_tenant_caps(req['tenant'], 1 << 60)
+
+    plan_df, _, _ = run_window(
+        req,
+        heat,
+        tiers,
+        tenant_caps,
+        lats,
+        now_ms,
+        pmin=0.0,
+        umin=-1.0,
+        min_io_bytes=0,
+        window_ms=20,
+        max_ops_per_tier=16,
+    )
+
+    waves = build_wave_specs(plan_df, req, window_ms=20, dtype="float16")
+    assert isinstance(waves, list)
+    assert len(waves) >= 1
+    w = waves[0]
+    # Required keys exist
+    for k in [
+        "pack_order",
+        "tile_order",
+        "bm",
+        "bn",
+        "bk",
+        "cluster_shape",
+        "tmem_layout",
+        "io_extents",
+        "swap_window",
+    ]:
+        assert k in w
+    # K granularity (in bytes) satisfies 32B
+    bk = int(w["bk"])
+    assert (bk * 2) % 32 == 0  # fp16/bf16
+    # extents non-empty and valid
+    assert len(w["io_extents"]) >= 1
+    assert int(w["tmem_layout"]["stage_n"]) >= 1
+    for layer, a, b in w["io_extents"]:
+        assert isinstance(layer, str)
+        assert int(b) >= int(a)
+    sb, se = w["swap_window"]
+    assert int(sb) < int(se)
+
+
+def test_validate_wave_spec_whitelist_and_granularity():
+    spec = {
+        "pack_order": [1, 2, 3],
+        "tile_order": [(0, 0), (0, 1)],
+        "bm": 128,
+        "bn": 128,
+        "bk": 64,
+        "cluster_shape": (2, 1),
+        "tmem_layout": {"columns": 8, "phases": 4, "double_buffer": True, "stage_n": 2},
+        "io_extents": [("0", 0, 3)],
+        "swap_window": (0, 8),
+    }
+    validate_wave_spec(spec)
+
+    invalid_k = spec | {"bk": 33}
+    with pytest.raises(ValueError):
+        validate_wave_spec(invalid_k)
+
+    whitelist = [TileConfig(64, 64, 32, 2, (1, 1))]
+    with pytest.raises(ValueError):
+        validate_wave_spec(spec, whitelist=whitelist)
+
+    good = spec | {
+        "bm": 64,
+        "bn": 64,
+        "bk": 32,
+        "cluster_shape": (1, 1),
+        "tmem_layout": {"columns": 8, "phases": 4, "double_buffer": True, "stage_n": 2},
+    }
+    validate_wave_spec(good, whitelist=whitelist)
+
+
+def test_validate_wave_spec_swap_window():
+    spec = {
+        "pack_order": [],
+        "tile_order": [(0, 0)],
+        "bm": 128,
+        "bn": 128,
+        "bk": 64,
+        "cluster_shape": (2, 1),
+        "tmem_layout": {"columns": 8, "phases": 4, "double_buffer": True, "stage_n": 2},
+        "io_extents": [("0", 0, 0)],
+        "swap_window": (4, 4),
+    }
+    with pytest.raises(ValueError):
+        validate_wave_spec(spec)
+
+
+def test_build_wave_specs_rejects_non_granular_shape():
+    plan_df = pd.DataFrame([
+        {
+            "node": "n0",
+            "tier_dst": 1,
+            "layer": 0,
+            "start_pid": 0,
+            "end_pid": 1,
+            "page_bytes": 256 * 1024,
+        }
+    ])
+    with pytest.raises(ValueError):
+        build_wave_specs(plan_df, pd.DataFrame(), window_ms=20, shapes=[(64, 64, 33)])


### PR DESCRIPTION
## Summary
- align planner WaveSpec contract with bw-runtime (tile_order, cluster_shape, swap_window)
- add bwrt adapter and documentation plus proto schema for WaveSpec
- extend unit coverage for wave spec validation and adapter conversions

## Testing
- BODOCACHE_PURE_PY=1 pytest
