### PR TITLE
fix: support context parallel sharding

### DIFF
--- a/bodocache/integrations/__init__.py
+++ b/bodocache/integrations/__init__.py
@@ -1,5 +1,5 @@
 from .base import KVRequest, PlannerInputs, build_dataframes
-from .vllm_adapter import VLLMBCacheAdapter
+from .vllm_adapter import VLLMBCacheAdapter, ContextParallelSpec
 from .sglang_adapter import SGLangBCacheAdapter
 
 __all__ = [
@@ -7,6 +7,6 @@ __all__ = [
     "PlannerInputs",
     "build_dataframes",
     "VLLMBCacheAdapter",
+    "ContextParallelSpec",
     "SGLangBCacheAdapter",
 ]
-

--- a/bodocache/integrations/vllm_integration.py
+++ b/bodocache/integrations/vllm_integration.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, Optional, Sequence
+from typing import Any, Callable, Dict, Optional, Sequence, Union
 
-from .vllm_adapter import VLLMBCacheAdapter, PrefetchResult
+from .vllm_adapter import VLLMBCacheAdapter, PrefetchResult, ContextParallelSpec
 from .vllm_blocks import VLLMCacheConfig, build_requests_from_blocks
 from .config import KVOverrides, apply_kv_overrides
 
@@ -11,6 +11,7 @@ from .config import KVOverrides, apply_kv_overrides
 CollectBlocksFn = Callable[[Any], Dict[int, Sequence[int]]]
 DestResolverFn = Callable[[Dict[str, Any]], Any]
 GetConfigFn = Callable[[Any], VLLMCacheConfig]
+ContextParallelResolver = Callable[[Any], Optional[ContextParallelSpec]]
 
 
 def _safe_get(obj: Any, path: Sequence[str], default: Any = None) -> Any:
@@ -104,6 +105,7 @@ class VLLMIntegration:
         dest_resolver: Optional[DestResolverFn] = None,
         kv_overrides: Optional[KVOverrides | Dict[str, Any]] = None,
         deadline_offset_ms: Optional[int] = None,
+        context_parallel: Optional[Union[ContextParallelSpec, ContextParallelResolver]] = None,
     ) -> None:
         self.engine = engine
         self.adapter = adapter
@@ -113,6 +115,7 @@ class VLLMIntegration:
         self._dest_resolver = dest_resolver
         self._kv_overrides = kv_overrides
         self._deadline_offset_ms = deadline_offset_ms
+        self._context_parallel = context_parallel
 
     def _config(self) -> VLLMCacheConfig:
         cfg = self._get_config(self.engine) if self._get_config is not None else _derive_config(self.engine)
@@ -144,11 +147,85 @@ class VLLMIntegration:
             now_ms=now_ms,
             deadline_offset_ms=int(self._deadline_offset_ms if self._deadline_offset_ms is not None else self.adapter.window_ms),
         )
+        ctx_spec = self._resolve_context_parallel(state)
         return self.adapter.prefetch(
             kv_reqs,
             now_ms=now_ms,
+            ctx_shard=ctx_spec,
             bandwidth_caps=bandwidth_caps,
             free_bytes=free_bytes,
             layer_lat_ms=layer_lat_ms,
             dest_resolver=self._dest_resolver,
         )
+
+    def _resolve_context_parallel(self, state: Any) -> Optional[ContextParallelSpec]:
+        spec = None
+        if self._context_parallel is not None:
+            if callable(self._context_parallel):
+                try:
+                    spec = self._context_parallel(state)
+                except Exception:
+                    spec = None
+            else:
+                spec = self._context_parallel
+        if spec is None:
+            spec = self._auto_context_parallel()
+        return _coerce_context_parallel_spec(spec)
+
+    def _auto_context_parallel(self) -> Optional[ContextParallelSpec]:
+        # Heuristics over engine attributes; returns None if world size <= 1 or unavailable.
+        engine = self.engine
+        world_size_paths = (
+            ("cache_config", "context_parallel_size"),
+            ("cache_config", "context_parallel_world_size"),
+            ("parallel_config", "context_parallel_size"),
+            ("parallel_config", "context_parallel_world_size"),
+            ("model_config", "context_parallel_size"),
+            ("llm_engine", "context_parallel_size"),
+            ("llm_engine", "parallel_config", "context_parallel_size"),
+        )
+        ws = _maybe_int(getattr(engine, "context_parallel_size", None), 0)
+        if ws <= 1:
+            for path in world_size_paths:
+                ws = _maybe_int(_safe_get(engine, path, None), 0)
+                if ws > 1:
+                    break
+        if ws <= 1:
+            return None
+        rank_paths = (
+            ("cache_config", "context_parallel_rank"),
+            ("parallel_config", "context_parallel_rank"),
+            ("llm_engine", "context_parallel_rank"),
+            ("llm_engine", "parallel_config", "context_parallel_rank"),
+        )
+        rk = _maybe_int(getattr(engine, "context_parallel_rank", None), 0)
+        for path in rank_paths:
+            if rk != 0:
+                break
+            rk_candidate = _safe_get(engine, path, None)
+            if rk_candidate is None:
+                continue
+            rk = _maybe_int(rk_candidate, rk)
+            if rk != 0:
+                break
+        return ContextParallelSpec(world_size=int(ws), rank=int(rk) % int(ws))
+
+
+def _coerce_context_parallel_spec(obj: Any) -> Optional[ContextParallelSpec]:
+    if obj is None:
+        return None
+    if isinstance(obj, ContextParallelSpec):
+        return obj if obj.world_size > 1 else None
+    if isinstance(obj, dict):
+        ws = _maybe_int(obj.get("world_size"), 0)
+        rk = _maybe_int(obj.get("rank"), 0)
+        if ws > 1:
+            return ContextParallelSpec(world_size=int(ws), rank=int(rk) % int(ws))
+        return None
+    if isinstance(obj, (tuple, list)) and len(obj) >= 2:
+        ws = _maybe_int(obj[0], 0)
+        rk = _maybe_int(obj[1], 0)
+        if ws > 1:
+            return ContextParallelSpec(world_size=int(ws), rank=int(rk) % int(ws))
+        return None
+    return None

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -6,7 +6,7 @@ import time
 from bodocache.adapters.segmented_file_backend import SegmentedFileBackend
 from bodocache.agent.node_agent import NodeAgent
 from bodocache.integrations.base import KVRequest
-from bodocache.integrations.vllm_adapter import VLLMBCacheAdapter
+from bodocache.integrations.vllm_adapter import VLLMBCacheAdapter, ContextParallelSpec
 from bodocache.agent.copy_engine import SimCopyEngine
 
 
@@ -59,3 +59,37 @@ def test_node_agent_with_engine_path(tmp_path):
     res = adapter.prefetch(reqs, now_ms=now_ms, dest_resolver=lambda info: 0, on_ready=lambda info: ready.append(info))
     assert res.exec_stats["ops"] >= 1
     assert ready, "on_ready should be called via engine path"
+
+
+def test_vllm_adapter_context_parallel_shard(tmp_path):
+    be = SegmentedFileBackend(str(tmp_path))
+    # Seed 4 pages for layer 0
+    page_bytes = 4096
+    for pid in range(4):
+        be.write_page("m", "v", 0, pid, page_bytes, secrets.token_bytes(page_bytes))
+    agent = NodeAgent(be, page_bytes=page_bytes)
+    adapter = VLLMBCacheAdapter(agent, node="n0", model_id="m", model_version="v", min_io_bytes=0)
+    now_ms = int(time.time() * 1000)
+    # Global request for pages [0..3]
+    req = KVRequest(
+        req_id="r",
+        node="n0",
+        model_id="m",
+        model_version="v",
+        prefix_id="p",
+        layer=0,
+        page_start=0,
+        page_end=3,
+        page_bytes=page_bytes,
+        tenant="t",
+        est_fill_ms=1.0,
+        tier_src=0,
+        tier_dst=2,
+        deadline_ms=now_ms + 1000,
+    )
+    # Rank 0 of 2 should own pages {0,2}
+    res0 = adapter.prefetch([req], now_ms=now_ms, ctx_shard=ContextParallelSpec(world_size=2, rank=0))
+    assert res0.exec_stats["bytes"] >= 2 * page_bytes
+    # Rank 1 of 2 should own pages {1,3}
+    res1 = adapter.prefetch([req], now_ms=now_ms, ctx_shard=ContextParallelSpec(world_size=2, rank=1))
+    assert res1.exec_stats["bytes"] >= 2 * page_bytes


### PR DESCRIPTION
## Summary
- add context parallel sharding option to vLLM adapter and auto detection in integration
- export sharding spec and cover with integration tests

## Testing
- BODOCACHE_PURE_PY=1 pytest tests/test_integrations.py tests/test_vllm_integration_dyn.py -q